### PR TITLE
Skip build jobs on delete events

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,6 +15,7 @@ env:
 
 jobs:
   build-amd64:
+    if: github.event_name != 'delete'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -53,6 +54,7 @@ jobs:
           cache-to: ${{ github.event_name == 'push' && format('type=registry,ref={0}/{1}:buildcache-amd64,mode=max', env.REGISTRY, env.IMAGE_NAME) || '' }}
 
   build-arm64:
+    if: github.event_name != 'delete'
     runs-on: ubuntu-24.04-arm
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Fix build jobs running unnecessarily on branch deletion events.

## Problem

When a branch is deleted, the `delete` event triggers the workflow. The `cleanup-branch-images` job correctly runs only on delete events, but the `build-amd64` and `build-arm64` jobs were also running because they lacked conditions to skip them.

## Solution

Add `if: github.event_name != 'delete'` to both build jobs so they skip on delete events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)