### PR TITLE
Delete multi-arch manifest tag on branch deletion

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -167,8 +167,8 @@ jobs:
           # Sanitize branch name (same logic as build jobs)
           SUFFIX=$(echo '${{ github.event.ref }}' | tr '/' '-')
 
-          for arch in amd64 arm64; do
-            TAG="${SUFFIX}-${arch}"
+          # Delete multi-arch manifest and arch-specific images
+          for TAG in "${SUFFIX}" "${SUFFIX}-amd64" "${SUFFIX}-arm64"; do
             echo "Looking for tag: $TAG"
 
             # Get version ID for this tag


### PR DESCRIPTION
## Summary

Fix branch cleanup to also delete the multi-arch manifest tag.

## Problem

When a branch is deleted, the cleanup job was only deleting:
- `:{branch}-amd64`
- `:{branch}-arm64`

But not the multi-arch manifest:
- `:{branch}`

## Solution

Update the loop to include all three tags: the base branch tag plus both arch-specific tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)