### PR TITLE
Fix cleanup job to handle multiple version IDs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -171,16 +171,20 @@ jobs:
           for TAG in "${SUFFIX}" "${SUFFIX}-amd64" "${SUFFIX}-arm64"; do
             echo "Looking for tag: $TAG"
 
-            # Get version ID for this tag
-            VERSION_ID=$(gh api \
+            # Get version IDs for this tag (may return multiple lines)
+            # Use index() for exact match instead of contains() which does substring matching
+            VERSION_IDS=$(gh api \
               "orgs/${{ github.repository_owner }}/packages/container/qprimer_designer/versions" \
-              --jq ".[] | select(.metadata.container.tags | contains([\"$TAG\"])) | .id" \
+              --jq ".[] | select(.metadata.container.tags | index(\"$TAG\")) | .id" \
               2>/dev/null || true)
 
-            if [ -n "$VERSION_ID" ]; then
-              gh api --method DELETE \
-                "orgs/${{ github.repository_owner }}/packages/container/qprimer_designer/versions/$VERSION_ID"
-              echo "Deleted version $VERSION_ID (tag: $TAG)"
+            if [ -n "$VERSION_IDS" ]; then
+              echo "$VERSION_IDS" | while read -r VERSION_ID; do
+                [ -z "$VERSION_ID" ] && continue
+                gh api --method DELETE \
+                  "orgs/${{ github.repository_owner }}/packages/container/qprimer_designer/versions/$VERSION_ID"
+                echo "Deleted version $VERSION_ID (tag: $TAG)"
+              done
             else
               echo "Tag $TAG not found, skipping"
             fi


### PR DESCRIPTION
## Summary

Fix the branch cleanup job that was failing with "invalid control character in URL".

## Problem

When deleting branch images, the jq query returned multiple version IDs (one per line) because:
1. `contains(["tag"])` does substring matching, not exact matching
2. Multiple versions can have the same tag

When `gh api --method DELETE` received the multi-line string, it failed with:
```
parse "https://api.github.com/.../versions/645914700\n645914447\n645913857": net/url: invalid control character in URL
```

## Solution

1. Use `index("tag")` instead of `contains(["tag"])` for exact tag matching
2. Iterate over each VERSION_ID line separately using `while read`
3. Delete each matching version individually

🤖 Generated with [Claude Code](https://claude.com/claude-code)