### PR TITLE
Fix Docker multi-arch manifest by disabling attestations

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -48,6 +48,8 @@ jobs:
           platforms: linux/amd64
           push: ${{ github.event_name == 'push' }}
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.suffix }}-amd64
+          provenance: false
+          sbom: false
           cache-from: |
             type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-amd64
             type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main-amd64
@@ -87,6 +89,8 @@ jobs:
           platforms: linux/arm64
           push: ${{ github.event_name == 'push' }}
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.suffix }}-arm64
+          provenance: false
+          sbom: false
           cache-from: |
             type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-arm64
             type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main-arm64


### PR DESCRIPTION
## Summary
- Disable provenance and SBOM attestations in Docker builds to fix multi-arch manifest
- Resolves "manifest unknown" error when pulling without `--platform` flag

## Problem
The `docker/build-push-action@v6` creates attestations (provenance and SBOM) by default, making each arch-specific tag (`main-amd64`, `main-arm64`) an OCI image index containing the image plus attestation manifests.

When `docker buildx imagetools create` references these indexes to build a multi-arch manifest, it creates a nested structure (manifest list of manifest lists) that Docker cannot properly resolve during pull without an explicit `--platform` flag.

**Symptoms:**
```bash
$ docker pull ghcr.io/broadinstitute/qprimer_designer:latest
manifest unknown

$ docker pull ghcr.io/broadinstitute/qprimer_designer:latest --platform linux/amd64
# Works! ✓
```

## Solution
Disable attestations (`provenance: false`, `sbom: false`) so arch-specific tags are simple OCI image manifests, allowing proper multi-arch manifest creation.

## Test plan
- [ ] Merge and verify `docker pull ghcr.io/broadinstitute/qprimer_designer:latest` works without `--platform` flag
- [ ] Confirm both amd64 and arm64 platforms are available in the multi-arch manifest

🤖 Generated with [Claude Code](https://claude.com/claude-code)