### PR TITLE
Bugfixes: reproducibility, CLI robustness, and model loading compatibility.

### DIFF
--- a/src/qprimer_designer/commands/build_output.py
+++ b/src/qprimer_designer/commands/build_output.py
@@ -23,7 +23,9 @@ primer-primer dimerization (ΔG).
 """,
     )
     parser.add_argument("--on", dest="eval_on", required=True, help="ON-target evaluation CSV")
-    parser.add_argument("--off", dest="eval_off", nargs="+", required=True, help="OFF-target evaluation CSVs")
+    # Fix: Use nargs="*" to allow zero OFF-target files (valid when CROSS and HOST are empty)
+    parser.add_argument("--off", dest="eval_off", nargs="*", default=[], help="OFF-target evaluation CSVs")
+    # Previous version: parser.add_argument("--off", dest="eval_off", nargs="+", required=True, help="OFF-target evaluation CSVs")
     parser.add_argument("--fa", dest="primers", required=True, help="Primer FASTA")
     parser.add_argument("--out", dest="output", required=True, help="Output CSV")
     parser.add_argument("--name", required=True, help="Target name")

--- a/src/qprimer_designer/commands/filter_primers.py
+++ b/src/qprimer_designer/commands/filter_primers.py
@@ -31,8 +31,17 @@ def run(args):
     num_select = int(params.get("NUM_TOP_SENSITIVITY", 100))
 
     # Load evaluation results
-    res = pd.read_csv(args.scores)
+    # Fix: Handle empty files gracefully (file exists but has no data or no columns)
+    try:
+        res = pd.read_csv(args.scores)
+    except pd.errors.EmptyDataError:
+        # File is empty or has no columns - write empty output and return
+        print(f"Warning: Scores file {args.scores} is empty, writing empty output")
+        open(args.out, "w").close()
+        return
+    # Previous version: res = pd.read_csv(args.scores)
     if res.empty:
+        print(f"Warning: Scores file {args.scores} has no data rows, writing empty output")
         open(args.out, "w").close()
         return
 

--- a/src/qprimer_designer/commands/generate.py
+++ b/src/qprimer_designer/commands/generate.py
@@ -3,6 +3,7 @@
 import argparse
 import bisect
 import random
+import re
 import time
 from collections import defaultdict
 
@@ -29,6 +30,7 @@ self-dimer free energy (ΔG).
     parser.add_argument("--out", dest="primer_seqs", required=True, help="Output FASTA for primers")
     parser.add_argument("--params", dest="param_file", required=True, help="Parameters file (params.txt)")
     parser.add_argument("--name", required=True, help="Name prefix for primer IDs")
+    parser.add_argument("--seed", type=int, default=None, help="Random seed for reproducible primer sampling (optional)")
     parser.set_defaults(func=run)
 
 
@@ -136,6 +138,11 @@ def run(args):
     forwards = list(for_filt.keys())
     reverses = list(rev_filt.keys())
 
+    # Set random seed for reproducibility if provided.
+    # Original code did not support seeding, making results non-reproducible.
+    if hasattr(args, "seed") and args.seed is not None:
+        random.seed(args.seed)
+
     # Randomly subsample to keep output bounded
     if len(forwards) > max_num // 2:
         forwards = random.sample(forwards, max_num // 2)
@@ -156,12 +163,27 @@ def run(args):
             fout.write(f">{pname}\n{seq}\n")
 
     features_df = pd.DataFrame(features).T
-    if features_df.empty:
+    # Original code: crashed with KeyError when no primers passed filtering,
+    # because 'pname' and 'forrev' columns are only added for primers written to output.
+    # if features_df.empty:
+    #     features_df = pd.DataFrame(columns=["pname", "pseq", "forrev", "len", "Tm", "GC", "dG"])
+    # else:
+    #     features_df = features_df.reset_index(names="pseq")[["pname", "pseq", "forrev", "len", "Tm", "GC", "dG"]]
+    #
+    # Fixed: check for 'pname' column presence, not just empty DataFrame.
+    if features_df.empty or "pname" not in features_df.columns:
         features_df = pd.DataFrame(columns=["pname", "pseq", "forrev", "len", "Tm", "GC", "dG"])
     else:
         features_df = features_df.reset_index(names="pseq")[["pname", "pseq", "forrev", "len", "Tm", "GC", "dG"]]
 
-    fname = args.primer_seqs.replace(".fa", ".feat")
+    # Original code: only handled .fa extension.
+    # fname = args.primer_seqs.replace(".fa", ".feat")
+    #
+    # Fixed: handle both .fa and .fasta extensions.
+    fname = re.sub(r"\.(fa|fasta)$", ".feat", args.primer_seqs, flags=re.IGNORECASE)
+    if fname == args.primer_seqs:
+        # If no recognized extension, append .feat
+        fname = args.primer_seqs + ".feat"
     features_df.to_csv(fname, index=False)
 
     runtime = time.time() - start_time

--- a/src/qprimer_designer/commands/pick_representatives.py
+++ b/src/qprimer_designer/commands/pick_representatives.py
@@ -41,15 +41,30 @@ for downstream primer design using MinHash-based approximate clustering.
 class MinHashFamily:
     """LSH family using MinHash for Jaccard distance."""
 
-    def __init__(self, kmer_size, N=1, use_fast_str_hash=False):
+    # BUG FIX: Added seed parameter for reproducibility.
+    # Original __init__ did not accept a seed, and make_h() used random.randint()
+    # without seeding, causing non-reproducible clustering results.
+    # Original:
+    # def __init__(self, kmer_size, N=1, use_fast_str_hash=False):
+    #     self.kmer_size = kmer_size
+    #     self.N = N
+    #     self.use_fast_str_hash = use_fast_str_hash
+    def __init__(self, kmer_size, N=1, use_fast_str_hash=False, seed=None):
         self.kmer_size = kmer_size
         self.N = N
         self.use_fast_str_hash = use_fast_str_hash
+        self.seed = seed
+        self._rng = random.Random(seed)  # Instance-specific RNG for reproducibility
 
     def make_h(self):
         p = 2**31 - 1
-        a = random.randint(1, p)
-        b = random.randint(0, p)
+        # BUG FIX: Use instance-specific RNG instead of global random.
+        # Original used random.randint() which is non-deterministic.
+        # Original:
+        # a = random.randint(1, p)
+        # b = random.randint(0, p)
+        a = self._rng.randint(1, p)
+        b = self._rng.randint(0, p)
 
         if self.use_fast_str_hash:
             def kmer_hash(x):
@@ -117,7 +132,11 @@ class HashConcatenation:
 
     def g(self, x):
         if self.join_as_str:
-            return ''.join(h(x) for h in self.hs)
+            # BUG FIX: h(x) returns a tuple, not a string, so str.join() fails.
+            # Convert each hash result to string before joining.
+            # Original:
+            # return ''.join(h(x) for h in self.hs)
+            return ''.join(str(h(x)) for h in self.hs)
         else:
             return tuple([h(x) for h in self.hs])
 
@@ -183,7 +202,13 @@ def find_low_gap_window(seqs, window_size=200):
     best_pos = 0
     min_gaps = float('inf')
 
-    for pos in range(0, max(1, seq_len - window_size)):
+    # BUG FIX: Off-by-one error - original code missed the last valid window position.
+    # For a 30bp sequence with window_size=20, last valid position is 10 (0-indexed).
+    # Original range(0, 10) checked 0-9, missing position 10.
+    # Fixed range(0, 11) checks 0-10 (all valid positions).
+    # Original:
+    # for pos in range(0, max(1, seq_len - window_size)):
+    for pos in range(0, max(1, seq_len - window_size + 1)):
         gaps = sum(s[pos:pos + window_size].count('-') for s in seqs)
         if gaps < min_gaps:
             min_gaps = gaps

--- a/src/qprimer_designer/commands/select_multiplex.py
+++ b/src/qprimer_designer/commands/select_multiplex.py
@@ -43,8 +43,16 @@ Selection rule (per input CSV / target):
 def infer_target_name(path: str) -> str:
     """Infer target name from filename like final/A.csv -> 'A'."""
     base = os.path.basename(path)
+    # Original code: case-sensitive extension matching (e.g., ".CSV" not handled).
+    # for ext in [".csv.gz", ".tsv.gz", ".csv", ".tsv"]:
+    #     if base.endswith(ext):
+    #         base = base[: -len(ext)]
+    #         break
+    #
+    # Fixed: use case-insensitive extension matching.
+    base_lower = base.lower()
     for ext in [".csv.gz", ".tsv.gz", ".csv", ".tsv"]:
-        if base.endswith(ext):
+        if base_lower.endswith(ext):
             base = base[: -len(ext)]
             break
     return base
@@ -96,9 +104,19 @@ def run(args):
     if args.top_n < 1:
         raise ValueError("--top-n must be >= 1")
 
+    # Original code: empty csvs list raised unclear pandas error "No objects to concatenate".
+    # Fixed: provide a clear error message for empty input.
+    if not args.csvs:
+        raise ValueError("No input CSV files provided. Please specify at least one CSV file.")
+
     selected_frames: List[pd.DataFrame] = []
 
     for path in args.csvs:
+        # Original code: relied on pandas error for missing files.
+        # Fixed: check file existence with a clear error message.
+        if not os.path.isfile(path):
+            raise FileNotFoundError(f"Input file not found: {path}")
+
         df = pd.read_csv(path)
 
         if args.target_from == "column":

--- a/src/qprimer_designer/models/inference.py
+++ b/src/qprimer_designer/models/inference.py
@@ -1,5 +1,6 @@
 """Model loading and inference utilities."""
 
+import __main__
 import warnings
 from importlib.resources import files
 from pathlib import Path
@@ -7,6 +8,40 @@ from typing import Tuple
 
 import joblib
 import torch
+
+from qprimer_designer.models.architectures import (
+    PGC,
+    DropoutNd,
+    S4DKernel,
+    S4D,
+    Janus,
+    MLP,
+    CombinedModel,
+    CombinedModelClassifier,
+    PcrDataset,
+)
+
+
+def _register_model_classes_for_pickle():
+    """Register model classes in __main__ for pickle compatibility.
+
+    Models saved with torch.save() when the class was defined in __main__
+    need the classes to be accessible from __main__ when loading.
+    """
+    if not hasattr(__main__, 'CombinedModelClassifier'):
+        __main__.PGC = PGC
+        __main__.DropoutNd = DropoutNd
+        __main__.S4DKernel = S4DKernel
+        __main__.S4D = S4D
+        __main__.Janus = Janus
+        __main__.MLP = MLP
+        __main__.CombinedModel = CombinedModel
+        __main__.CombinedModelClassifier = CombinedModelClassifier
+        __main__.PcrDataset = PcrDataset
+
+
+# Register classes at import time
+_register_model_classes_for_pickle()
 
 
 def get_model_path(filename: str) -> Path:

--- a/src/qprimer_designer/utils/encoding.py
+++ b/src/qprimer_designer/utils/encoding.py
@@ -9,7 +9,18 @@ def one_hot_encode(seq: str, length: int = 28) -> np.ndarray:
     One-hot encode a nucleotide sequence with gap support.
 
     Encoding order: A, T, C, G, gap
-    Sequence is left-padded/truncated to fixed length.
+
+    BUG FIX: Corrected docstring to match actual behavior.
+    Original docstring said "left-padded/truncated" but code actually:
+    - Right-pads short sequences with 'N' (ljust)
+    - Keeps the LAST N characters for long sequences ([-length:])
+
+    # Original docstring:
+    # Sequence is left-padded/truncated to fixed length.
+
+    Sequence handling:
+    - Short sequences: Right-padded with 'N' to reach fixed length
+    - Long sequences: Last N characters are kept (left-truncated)
 
     Args:
         seq: DNA/RNA sequence
@@ -26,6 +37,7 @@ def one_hot_encode(seq: str, length: int = 28) -> np.ndarray:
         "N": [0, 0, 0, 0, 0],
         "-": [0, 0, 0, 0, 1],
     }
+    # Right-pad with N, then take last 'length' characters
     seq = seq.ljust(length, "N")[-length:]
     return np.array([mapping[c.upper()] for c in seq])
 

--- a/src/qprimer_designer/utils/params.py
+++ b/src/qprimer_designer/utils/params.py
@@ -19,7 +19,12 @@ def parse_params(param_file: str | Path) -> dict[str, Any]:
     params = {}
     with open(param_file) as f:
         for line in f:
-            if "=" in line:
+            # BUG FIX: Skip comment lines before checking for '='
+            # Original code only checked `if "=" in line:` which incorrectly
+            # parsed comment lines like '# MAX_VALUE = 100' as parameters.
+            # Original:
+            # if "=" in line:
+            if "=" in line and not line.lstrip().startswith("#"):
                 name, value = line.split("=", 1)
                 name = name.strip()
                 value = value.strip()


### PR DESCRIPTION
## Changes

### Reproducibility
- Add seed parameter to `MinHashFamily` for deterministic clustering
- Fix off-by-one error in `find_low_gap_window()` (last position was skipped)
- Fix `join_as_str` mode in `HashConcatenation`
- Fix comment parsing in `params.py` (lines with `#` were incorrectly parsed)
- Correct misleading docstring in `one_hot_encode()`

### CLI Validation
- Add `--seed` argument to `generate` command
- Fix `KeyError` when no primers pass filtering
- Support both `.fa` and `.fasta` extensions
- Add case-insensitive extension matching in `select_multiplex`
- Add file existence validation with clear error messages
- Handle empty score files in `filter_primers`
- Allow zero OFF-target files in `build_output`

### Model Loading
- Register model classes in `__main__` for pickle compatibility
- Fixes `AttributeError: Can't get attribute 'CombinedModelClassifier'` when running via CLI

## Test Plan
- [ ] Verify clustering reproducibility with `--seed`
- [ ] Confirm `qprimer evaluate` works via CLI
- [ ] Test with mixed-case file extensions