### PR TITLE
Add plotly and pycountry to GUI dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = ["pytest>=8.0", "pytest-cov>=4.1"]
-gui = ["streamlit>=1.30"]
+gui = ["streamlit>=1.30", "plotly>=5.18", "pycountry>=23.12"]
 
 [project.scripts]
 qprimer = "qprimer_designer.cli:main"


### PR DESCRIPTION
## Summary

- Add `plotly>=5.18` and `pycountry>=23.12` to `[gui]` optional dependencies in pyproject.toml
- These are required by the Virus Map feature but were missing, causing import errors on fresh installs

## Test plan

- [ ] `pip install ".[gui]"` installs plotly and pycountry
- [ ] Virus Map page loads without import errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)