### PR TITLE
Add probe-first quick design mode with greedy probe assignment

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -5,14 +5,14 @@
 ############################################
 
 # SINGLEPLEX REQUIRED: user must fill these for singleplex, ignored if not multiplex
-TARGETS = ['test space file']
-CROSS   = []
+TARGETS = ['Bundibugyo_seqs']
+CROSS   = ['EBOVZ_from2022', 'EBOV_S_all']
 
 # shared option for multiplex and singleplex
 HOST    = []
 
 # MULTIPLEX REQUIRED: Multiplex targets, will be ignored if not multiplex
-PANEL = ['TEST', 'TEST_2']
+PANEL = []
 
 # Derived sets
 OFF_TARGETS = CROSS + HOST
@@ -28,7 +28,7 @@ TARGET_DIR = "target_seqs/original"
 PARAMS = "params.txt"
 
 # Run ID for unique output directories (set automatically or override)
-RUN_ID = ""
+RUN_ID = "20260519_000816"
 
 # Pipeline Design Options
 MULTIPLEX = bool(int(config.get("multiplex", 0)))
@@ -588,6 +588,7 @@ rule evaluate_pset:
         eval_on=f"{RUN_DIR}/_{PRIMARY_TARGET}/{{filename}}.{PRIMARY_TARGET}.eval",
         eval_off=lambda wc: [f"{RUN_DIR}/_{t}/{wc.filename}.{t}.eval" for t in OFF_TARGETS],
         fasta=f"{RUN_DIR}/{{filename}}.fa",
+        off_refs=lambda wc: [f"target_seqs/original/{t}.fa" for t in OFF_TARGETS],
         mapped_on=lambda wc: (
             f"{RUN_DIR}/_{PRIMARY_TARGET}/{wc.filename}.{PRIMARY_TARGET}.mapped"
             if EVAL_HAS_PROBE else []
@@ -605,6 +606,7 @@ rule evaluate_pset:
     params:
         ids=lambda wc: " ".join(shlex.quote(i) for i in check_ids(f"{RUN_DIR}/{wc.filename}.fa")),
         off_arg=lambda wc, input: "--off " + " ".join(shlex.quote(str(f)) for f in input.eval_off) if input.eval_off else "",
+        off_ref_arg=lambda wc, input: "--off-ref " + " ".join(shlex.quote(str(f)) for f in input.off_refs) if input.off_refs else "",
         probe_args=lambda wc, input: (
             f"--mapped-on {shlex.quote(str(input.mapped_on))} "
             f"--mapped-off {' '.join(shlex.quote(str(f)) for f in input.mapped_off)} "
@@ -617,6 +619,7 @@ rule evaluate_pset:
         "qprimer export-report "
         "--on '{input.eval_on}' "
         "{params.off_arg} "
+        "{params.off_ref_arg} "
         "--out '{output}' "
         "--names {params.ids} "
         "{params.probe_args} "
@@ -686,7 +689,6 @@ rule align_probes:
     params:
         reference=lambda wc: f"{RUN_DIR}/_intermediate/{wc.target}",
         multiMap=lambda wc: min(count_seqs(wc.target) * 2, 50000),
-        # Permissive alignment (6mm/20mer); mismatch filtering done post-alignment
         mapOption="--mp 3,3 --np 2 --rdg 6,4 --rfg 6,4 -L 6 -N 1 --score-min L,-0.6,-0.6"
     shell:
         "bowtie2 -x '{params.reference}' -U '{input.fasta}' -f "
@@ -823,7 +825,7 @@ rule evaluate:
     resources:
         gpu=1
     params:
-        ref_type=lambda wc: "on" if (wc.virus == wc.target or EVALUATE) else "off"
+        ref_type=lambda wc: "on" if (wc.virus == wc.target or (EVALUATE and wc.target == PRIMARY_TARGET)) else "off"
     shell:
         "qprimer evaluate "
         "--in '{input.inp}' --out '{output}' "

--- a/gui/app.py
+++ b/gui/app.py
@@ -86,8 +86,7 @@ def _build_fetch_command(
 # ---------------------------------------------------------------------------
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 FASTA_DIR = PROJECT_ROOT / "target_seqs" / "original"
-FINAL_DIR = PROJECT_ROOT / "final"
-EVALUATE_DIR = PROJECT_ROOT / "evaluate"
+RUNS_DIR = PROJECT_ROOT / "runs"
 SCHEMATIC_PATH = PROJECT_ROOT / "schematic.png"
 
 # Ensure the upload directory exists
@@ -155,7 +154,7 @@ def _reset_workflow_state():
                 "eval_method", "eval_for", "eval_rev", "eval_pro",
                 "_eval_for_saved", "_eval_rev_saved", "_eval_pro_saved",
                 "eval_pset_path", "eval_pset_upload",
-                "mode", "design_mode", "probe_enabled",
+                "mode", "design_mode", "probe_enabled", "_probe_enabled_saved",
                 "run_id", "design_run_id",
                 "monitor_spreadsheet_url", "monitor_spreadsheet_data",
                 "monitor_query_ids", "monitor_email_recipients",
@@ -167,6 +166,29 @@ def _reset_workflow_state():
                 "monitor_resume_run"):
         st.session_state.pop(key, None)
     _clear_pipeline_state()
+
+
+def _save_fasta_bytes(path: Path, data: bytes) -> None:
+    """Write FASTA bytes ensuring the file ends with a newline.
+
+    Some tools (e.g. bowtie2) silently drop the last base of the last
+    sequence when a FASTA file does not end with a newline character.
+    """
+    if data and not data.endswith(b"\n"):
+        data += b"\n"
+    path.write_bytes(data)
+
+
+def _pset_has_probe(fasta_path: str) -> bool:
+    """Check if a FASTA file contains probe entries (*_pro)."""
+    try:
+        with open(fasta_path) as f:
+            for line in f:
+                if line.startswith(">") and line.strip().endswith("_pro"):
+                    return True
+    except (FileNotFoundError, OSError):
+        pass
+    return False
 
 
 def _current_page() -> str:
@@ -384,25 +406,28 @@ def _format_size(nbytes: int) -> str:
 # Default parameter values (matches params.txt.template)
 DEFAULT_PARAMS: dict = {
     "DESIGN_WINDOW": 500,
-    "MAX_PRIMER_CANDIDATES": 10000,
     "TM_MIN": 55,
     "TM_MAX": 60,
     "GC_MAX": 60,
     "DG_MIN": -6,
     "PRIMER_LEN_MIN": 19,
     "PRIMER_LEN_MAX": 21,
-    "TILING_STEP": 5,
+    "QUICK_N_POSITIONS": 100,
+    "QUICK_N_VARIANTS": 10,
+    "QUICK_COV_MIN": 1.0,
+    "QUICK_ACT_MIN": 1.0,
     "PROBE_LEN_MIN": 24,
-    "PROBE_LEN_MAX": 28,
+    "PROBE_LEN_MAX": 26,
     "PROBE_TM_MIN": 65,
-    "PROBE_TM_MAX": 70,
+    "PROBE_TM_MAX": 75,
     "PROBE_GC_MAX": 60,
     "PROBE_DG_MIN": -8,
-    "PROBE_HOMOPOLYMER_MAX": 3,
-    "PROBE_AVOID_5PRIME_G": True,
+    "PROBE_HOMOPOLYMER_MAX": 4,
+    "PROBE_AVOID_5PRIME_G": False,
     "PROBE_CONSERVATION_THRESHOLD": 0.8,
     "PROBE_MAX_MISMATCHES": 2,
-    "PROBE_AMPLICON_BUFFER": 20,
+    "PROBE_MAX_INDELS": 0,
+    "PROBE_AMPLICON_BUFFER": 15,
     "MIN_PROBES_PER_PAIR": 1,
     "MAX_PROBES_PER_PAIR": 5,
     "AMPLEN_MIN": 60,
@@ -470,7 +495,7 @@ def _render_sidebar():
         if st.button(":material/public: Global Virus Distribution", key="sidebar_virus_map", type="tertiary"):
             _navigate("virus_map")
             st.rerun()
-        if FINAL_DIR.exists() and any(FINAL_DIR.iterdir()):
+        if RUNS_DIR.exists() and any(RUNS_DIR.iterdir()):
             if st.button(":material/stacks: Past Results", key="sidebar_results", type="tertiary"):
                 _navigate("results")
                 st.rerun()
@@ -502,8 +527,9 @@ def _render_sidebar():
                 st.markdown(f"**Off-targets:** {', '.join(off_targets) if off_targets else '—'}")
 
                 # Probe
-                if "probe_enabled" in st.session_state:
-                    probe = st.session_state["probe_enabled"]
+                if "probe_enabled" in st.session_state or "_probe_enabled_saved" in st.session_state:
+                    probe = st.session_state.get("probe_enabled",
+                                                  st.session_state.get("_probe_enabled_saved", False))
                     st.markdown(f"**Probe:** {'On' if probe else 'Off'}")
                 else:
                     st.markdown("**Probe:** —")
@@ -1273,7 +1299,7 @@ def _tab_files():
                 if not dest:
                     st.error(f"Invalid filename: {f.name}")
                     continue
-                dest.write_bytes(_bz2.decompress(f.getvalue()))
+                _save_fasta_bytes(dest, _bz2.decompress(f.getvalue()))
             elif p.suffix.lower() not in (".fa", ".fasta", ".fna"):
                 st.error(f"Unsupported extension: {p.suffix}")
                 continue
@@ -1283,7 +1309,7 @@ def _tab_files():
                 if not dest:
                     st.error(f"Invalid filename: {f.name}")
                     continue
-                dest.write_bytes(f.getvalue())
+                _save_fasta_bytes(dest, f.getvalue())
             # Remove any leftover files with other FASTA extensions
             for ext in (".fasta", ".fna"):
                 old = FASTA_DIR / (p.stem + ext)
@@ -1396,7 +1422,7 @@ def _tab_configuration():
                     pset_dir = PROJECT_ROOT / "evaluate"
                     pset_dir.mkdir(parents=True, exist_ok=True)
                     pset_path = pset_dir / pset_upload.name
-                    pset_path.write_bytes(pset_upload.getvalue())
+                    _save_fasta_bytes(pset_path, pset_upload.getvalue())
                     st.session_state["eval_pset_path"] = str(pset_path)
                     st.session_state["_eval_pset_saved"] = fid
                 st.success(f"Saved {pset_upload.name}")
@@ -1444,19 +1470,54 @@ def _tab_parameters(mode: str = "design"):
                 "OFFLEN_MAX", value=int(p["OFFLEN_MAX"]),
                 min_value=30, step=100, key="p_off_max",
             )
+
+        # Show probe cutoffs when a probe sequence is provided
+        eval_pro = st.session_state.get("_eval_pro_saved", "") or st.session_state.get("eval_pro", "")
+        eval_pset = st.session_state.get("eval_pset_path", "")
+        has_probe_seq = bool(eval_pro) or (bool(eval_pset) and _pset_has_probe(eval_pset))
+        if has_probe_seq:
+            with st.expander("Probe filtering", expanded=True):
+                c15, c16 = st.columns(2)
+                p["PROBE_MAX_MISMATCHES"] = c15.number_input(
+                    "PROBE_MAX_MISMATCHES", value=int(p["PROBE_MAX_MISMATCHES"]),
+                    min_value=0, max_value=10, key="p_eval_probe_mm",
+                    help="Maximum mismatches for probe to count as matched",
+                )
+                p["PROBE_MAX_INDELS"] = c16.number_input(
+                    "PROBE_MAX_INDELS", value=int(p["PROBE_MAX_INDELS"]),
+                    min_value=0, max_value=5, key="p_eval_probe_indel",
+                    help="Maximum indels for probe to count as matched",
+                )
         return
+
+    # Check if any selected target has >1 sequence (quick mode)
+    selected_targets = st.session_state.get("targets", [])
+    is_quick = any(
+        _fasta_info(t).get("seqs", 0) > 1 for t in selected_targets
+    ) if selected_targets else False
 
     # --- Primer generation ---
     with st.expander("Primer generation", expanded=True):
-        p["DESIGN_WINDOW"] = st.number_input(
-            "Alignment window size (bp)", value=int(p["DESIGN_WINDOW"]),
-            min_value=50, step=50, key="p_design_window",
-            help="Window size for dividing the MSA when selecting representative sequences.",
-        )
-        p["MAX_PRIMER_CANDIDATES"] = st.number_input(
-            "MAX_PRIMER_CANDIDATES", value=int(p["MAX_PRIMER_CANDIDATES"]),
-            min_value=100, step=1000, key="p_max_cand",
-        )
+        if is_quick:
+            st.caption("Multi-sequence target detected — using quick design mode.")
+            c_q1, c_q2 = st.columns(2)
+            p["QUICK_N_POSITIONS"] = c_q1.number_input(
+                "MSA sites to explore", value=int(p["QUICK_N_POSITIONS"]),
+                min_value=10, max_value=1000, step=10, key="p_quick_n_pos",
+                help="Number of top conserved amplicon positions to evaluate across the MSA.",
+            )
+            p["QUICK_N_VARIANTS"] = c_q2.number_input(
+                "Primer variants per site", value=int(p["QUICK_N_VARIANTS"]),
+                min_value=1, max_value=50, step=1, key="p_quick_n_var",
+                help="Number of wobble-optimized primer variants per position per direction.",
+            )
+        else:
+            p["DESIGN_WINDOW"] = st.number_input(
+                "Alignment window size (bp)", value=int(p["DESIGN_WINDOW"]),
+                min_value=50, step=50, key="p_design_window",
+                help="Window size for dividing the MSA when selecting representative sequences.",
+            )
+
         c1, c2 = st.columns(2)
         p["TM_MIN"] = c1.number_input(
             "TM_MIN", value=float(p["TM_MIN"]), step=0.5, key="p_tm_min",
@@ -1486,10 +1547,6 @@ def _tab_parameters(mode: str = "design"):
         if p["PRIMER_LEN_MIN"] > p["PRIMER_LEN_MAX"]:
             st.warning("PRIMER_LEN_MIN should be <= PRIMER_LEN_MAX")
 
-        p["TILING_STEP"] = st.number_input(
-            "TILING_STEP", value=int(p["TILING_STEP"]),
-            min_value=1, max_value=50, key="p_tiling",
-        )
 
     # --- Probe generation ---
     probe_enabled = st.session_state.get("probe_enabled", False)
@@ -1538,19 +1595,9 @@ def _tab_parameters(mode: str = "design"):
             )
 
         with st.expander("Probe mode configuration", expanded=False):
-            p["PROBE_CONSERVATION_THRESHOLD"] = st.number_input(
-                "PROBE_CONSERVATION_THRESHOLD",
-                value=float(p["PROBE_CONSERVATION_THRESHOLD"]),
-                min_value=0.0, max_value=1.0, step=0.05, key="p_probe_cons",
-                help="Minimum fraction of sequences sharing the same base at a column for it to be considered conserved.",
-            )
             p["PROBE_MAX_MISMATCHES"] = st.number_input(
                 "PROBE_MAX_MISMATCHES", value=int(p["PROBE_MAX_MISMATCHES"]),
                 min_value=0, max_value=10, key="p_probe_mm",
-            )
-            p["PROBE_AMPLICON_BUFFER"] = st.number_input(
-                "PROBE_AMPLICON_BUFFER (nt)", value=int(p["PROBE_AMPLICON_BUFFER"]),
-                min_value=0, max_value=100, key="p_probe_buf",
             )
             c9, c10 = st.columns(2)
             p["MIN_PROBES_PER_PAIR"] = c9.number_input(
@@ -1592,6 +1639,18 @@ def _tab_parameters(mode: str = "design"):
             "NUM_TOP_SENSITIVITY", value=int(p["NUM_TOP_SENSITIVITY"]),
             min_value=10, step=10, key="p_num_top",
         )
+        if is_quick:
+            c_ev1, c_ev2 = st.columns(2)
+            p["QUICK_COV_MIN"] = c_ev1.number_input(
+                "Coverage goal", value=float(p.get("QUICK_COV_MIN", 1.0)),
+                min_value=0.0, max_value=1.0, step=0.05, key="p_quick_cov",
+                help="Minimum coverage fraction for early stopping (1.0 = all sequences).",
+            )
+            p["QUICK_ACT_MIN"] = c_ev2.number_input(
+                "Activity goal", value=float(p.get("QUICK_ACT_MIN", 1.0)),
+                min_value=0.0, max_value=1.0, step=0.05, key="p_quick_act",
+                help="Minimum activity fraction for early stopping (1.0 = all sequences).",
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -1601,7 +1660,8 @@ def _tab_parameters(mode: str = "design"):
 def _build_command() -> list[str]:
     """Build the snakemake command list from current session state."""
     mode = st.session_state.get("mode", "Singleplex")
-    probe = st.session_state.get("probe_enabled", False)
+    probe = st.session_state.get("probe_enabled",
+                                  st.session_state.get("_probe_enabled_saved", False))
     cores = st.session_state.get("cores", 1)
     dry_run = st.session_state.get("dry_run", False)
 
@@ -1671,7 +1731,8 @@ def _preflight_checks() -> list[str]:
 def _write_pipeline_files():
     """Write Snakefile and params.txt to project root."""
     mode = st.session_state.get("mode", "Singleplex")
-    probe = st.session_state.get("probe_enabled", False)
+    probe = st.session_state.get("probe_enabled",
+                                  st.session_state.get("_probe_enabled_saved", False))
 
     targets = st.session_state.get("targets", [])
     cross = st.session_state.get("cross", [])
@@ -1702,7 +1763,7 @@ def _write_pipeline_files():
 
 
 # Pipeline rule steps grouped for progress display
-_PIPELINE_RULES_DESIGN = [
+_PIPELINE_RULES_DESIGN_STANDARD = [
     ("make_MSA", "Building multiple sequence alignment"),
     ("pick_representative_seqs", "Selecting representative sequences"),
     ("generate_primers", "Generating primer candidates"),
@@ -1715,6 +1776,12 @@ _PIPELINE_RULES_DESIGN = [
     ("rescue_evaluate", "Rescue evaluation"),
     ("filter_primer_list", "Filtering and ranking primers"),
     ("check_coverage", "Checking primer coverage"),
+]
+
+_PIPELINE_RULES_DESIGN_QUICK = [
+    ("make_MSA", "Building multiple sequence alignment"),
+    ("quick_design_on_target", "Designing with AI"),
+    ("filter_primer_list", "Filtering and ranking primers"),
 ]
 
 _PIPELINE_RULES_EVALUATE = [
@@ -1731,7 +1798,12 @@ def _get_pipeline_rules() -> list[tuple[str, str]]:
     mode = st.session_state.get("mode", "Singleplex")
     if mode == "Evaluate":
         return _PIPELINE_RULES_EVALUATE
-    return _PIPELINE_RULES_DESIGN
+    # Check if any target has >1 sequence (quick mode)
+    targets = st.session_state.get("targets", [])
+    is_quick = any(_fasta_info(t).get("seqs", 0) > 1 for t in targets) if targets else False
+    if is_quick:
+        return _PIPELINE_RULES_DESIGN_QUICK
+    return _PIPELINE_RULES_DESIGN_STANDARD
 
 
 def _get_all_targets() -> list[str]:
@@ -1747,8 +1819,8 @@ _PER_TARGET_RULES = {
     "build_index", "align", "align_probes", "parse_map", "parse_probe_mapping",
     "process_map", "check_coverage", "prepare_input", "evaluate",
     "make_MSA", "pick_representative_seqs", "generate_primers",
-    "resolve_target_seq", "choose_target_seq", "generate_probes",
-    "filter_primer_list", "build_final_output",
+    "resolve_target_seq", "generate_probes",
+    "filter_primer_list", "build_final_output", "quick_design_on_target",
 }
 
 
@@ -1769,7 +1841,8 @@ def _save_run_config():
         "targets": st.session_state.get("targets", []),
         "cross_reactivity": st.session_state.get("cross", []),
         "host": st.session_state.get("host", []),
-        "probe_enabled": st.session_state.get("probe_enabled", False),
+        "probe_enabled": st.session_state.get("probe_enabled",
+                                              st.session_state.get("_probe_enabled_saved", False)),
         "cores": st.session_state.get("cores", 1),
     }
 
@@ -1805,10 +1878,7 @@ def _save_run_config():
     config["parameters"] = dict(st.session_state.get("params", {}))
 
     # Determine output directory
-    if mode == "Evaluate":
-        out_dir = PROJECT_ROOT / "evaluate" / run_id
-    else:
-        out_dir = PROJECT_ROOT / "final" / run_id
+    out_dir = RUNS_DIR / run_id
     out_dir.mkdir(parents=True, exist_ok=True)
 
     # Custom JSON serializer for dates
@@ -1902,9 +1972,17 @@ def _tab_run():
 
         env = os.environ.copy()
         env["PYTHONUNBUFFERED"] = "1"
+        # Ensure the conda env bin dir is on PATH (for sam2pairwise, bowtie2, etc.)
+        # Use snakemake's location to find the correct env bin dir, since
+        # CONDA_PREFIX may point to the base env rather than qprimer-designer.
+        snakemake_path = _find_tool("snakemake")
         env_bin = str(Path(sys.executable).parent)
-        if env_bin not in env.get("PATH", ""):
-            env["PATH"] = env_bin + os.pathsep + env.get("PATH", "")
+        extra_dirs = [env_bin]
+        if snakemake_path:
+            extra_dirs.append(str(Path(snakemake_path).parent))
+        for d in extra_dirs:
+            if d and d not in env.get("PATH", ""):
+                env["PATH"] = d + os.pathsep + env.get("PATH", "")
 
         cmd = _build_command()
 
@@ -2582,13 +2660,13 @@ def _tab_results():
 
     # Allow browsing past runs
     past_runs = []
-    if workflow == "design" and FINAL_DIR.exists():
+    if workflow == "design" and RUNS_DIR.exists():
         past_runs = sorted(
-            [d.name for d in FINAL_DIR.iterdir() if d.is_dir()],
+            [d.name for d in RUNS_DIR.iterdir() if d.is_dir()],
             reverse=True,
         )
     elif workflow in ("evaluate", "monitor"):
-        browse_dir = MONITOR_DIR if workflow == "monitor" else EVALUATE_DIR
+        browse_dir = MONITOR_DIR if workflow == "monitor" else RUNS_DIR
         if browse_dir.exists():
             past_runs = sorted(
                 [d.name for d in browse_dir.iterdir() if d.is_dir()],
@@ -2614,13 +2692,14 @@ def _tab_results():
     if workflow == "design":
         st.subheader("Final output files")
 
-        if run_id and (FINAL_DIR / run_id).exists():
-            csvs = sorted((FINAL_DIR / run_id).glob("**/*.csv"), reverse=True)
+        run_dir = RUNS_DIR / run_id if run_id else None
+        if run_dir and run_dir.exists():
+            csvs = sorted(run_dir.glob("*_final.csv"), reverse=True)
         else:
             csvs = []
 
         if csvs:
-            csv_labels = [str(c.relative_to(FINAL_DIR / run_id)) for c in csvs]
+            csv_labels = [c.name for c in csvs]
 
             selected_csv_label = st.selectbox(
                 "Select CSV to view",
@@ -2630,7 +2709,7 @@ def _tab_results():
             if selected_csv_label:
                 import pandas as pd
 
-                csv_path = FINAL_DIR / run_id / selected_csv_label
+                csv_path = run_dir / selected_csv_label
                 try:
                     df = pd.read_csv(csv_path)
                     st.write(f"**{len(df)} primer pairs**")
@@ -2681,7 +2760,7 @@ def _tab_results():
             if tree_target:
                 msa_path = MSA_DIR / f"{tree_target}.aln"
                 meta_path = FASTA_DIR / f"{tree_target}_metadata.csv"
-                tree_dir = FINAL_DIR / run_id / "trees" if run_id else None
+                tree_dir = run_dir / "trees" if run_dir else None
 
                 if not msa_path.exists():
                     st.warning(f"MSA file not found: `{msa_path.name}`. Run the pipeline first.")
@@ -2751,14 +2830,13 @@ def _tab_results():
                                 covered_ids = None
                                 with ctrl_col:
                                     # Find eval.re files for this target
-                                    outputs_dir = PROJECT_ROOT / "outputs"
-                                    eval_re_files = sorted(outputs_dir.glob(
+                                    eval_re_files = sorted(run_dir.glob(
                                         f"*{tree_target}*.eval.re"
-                                    )) if outputs_dir.exists() else []
+                                    )) if run_dir and run_dir.exists() else []
 
                                     if eval_re_files and csvs:
                                         import pandas as pd
-                                        csv_path = FINAL_DIR / run_id / csv_labels[0]
+                                        csv_path = run_dir / csv_labels[0]
                                         final_df = pd.read_csv(csv_path)
                                         if len(final_df) > 0:
                                             pair_options = [
@@ -2820,8 +2898,8 @@ def _tab_results():
 
         if workflow == "monitor" and run_id and (MONITOR_DIR / run_id).exists():
             xlsx_files = sorted((MONITOR_DIR / run_id).glob("*.xlsx"), reverse=True)
-        elif run_id and (EVALUATE_DIR / run_id).exists():
-            xlsx_files = sorted((EVALUATE_DIR / run_id).rglob("*.xlsx"), reverse=True)
+        elif run_id and (RUNS_DIR / run_id).exists():
+            xlsx_files = sorted((RUNS_DIR / run_id).rglob("*.xlsx"), reverse=True)
         else:
             xlsx_files = []
 
@@ -3032,7 +3110,7 @@ def _page_select_target():
                 if not dest:
                     st.error(f"Invalid filename: {f.name}")
                     continue
-                dest.write_bytes(f.getvalue())
+                _save_fasta_bytes(dest, f.getvalue())
                 for ext in (".fasta", ".fna"):
                     old = FASTA_DIR / (p.stem + ext)
                     if old.exists():
@@ -3458,7 +3536,7 @@ def _page_select_offtarget():
                     if not dest:
                         st.error(f"Invalid filename: {f.name}")
                         continue
-                    dest.write_bytes(f.getvalue())
+                    _save_fasta_bytes(dest, f.getvalue())
                     for ext in (".fasta", ".fna"):
                         old = FASTA_DIR / (p.stem + ext)
                         if old.exists():
@@ -3527,7 +3605,7 @@ def _page_select_offtarget():
                 if not dest:
                     st.error(f"Invalid filename: {f.name}")
                     continue
-                dest.write_bytes(f.getvalue())
+                _save_fasta_bytes(dest, f.getvalue())
                 for ext in (".fasta", ".fna"):
                     old = FASTA_DIR / (p.stem + ext)
                     if old.exists():
@@ -3593,7 +3671,9 @@ def _config_design():
 
     st.divider()
 
-    # Probe design
+    # Probe design — restore saved value if widget key was cleared by navigation
+    if "probe_enabled" not in st.session_state and "_probe_enabled_saved" in st.session_state:
+        st.session_state["probe_enabled"] = st.session_state["_probe_enabled_saved"]
     st.checkbox("Enable probe design", key="probe_enabled")
 
     # Parameters
@@ -3608,6 +3688,9 @@ def _config_design():
             st.rerun()
     with col_cont:
         if st.button("Continue →", type="primary", use_container_width=True, key="design_cont"):
+            # Persist widget value before navigating — Streamlit clears
+            # widget-bound keys when the widget is no longer rendered.
+            st.session_state["_probe_enabled_saved"] = st.session_state.get("probe_enabled", False)
             st.session_state._run_page_fresh = True
             _navigate("run")
             st.rerun()
@@ -3651,7 +3734,7 @@ def _page_eval_primer():
             pset_dir = PROJECT_ROOT / "evaluate"
             pset_dir.mkdir(parents=True, exist_ok=True)
             pset_path = pset_dir / pset_upload.name
-            pset_path.write_bytes(pset_upload.getvalue())
+            _save_fasta_bytes(pset_path, pset_upload.getvalue())
             st.session_state["eval_pset_path"] = str(pset_path)
             st.success(f"Saved {pset_upload.name}")
 
@@ -4008,7 +4091,7 @@ def _page_monitor_primer():
             if _id not in saved:
                 pset_path = PROJECT_ROOT / "evaluate" / uploaded.name
                 pset_path.parent.mkdir(parents=True, exist_ok=True)
-                pset_path.write_bytes(uploaded.getvalue())
+                _save_fasta_bytes(pset_path, uploaded.getvalue())
                 st.session_state["monitor_pset_path"] = str(pset_path)
                 saved.add(_id)
             st.success(f"Uploaded: {uploaded.name}")
@@ -4432,9 +4515,14 @@ def _run_monitor():
 
             env = os.environ.copy()
             env["PYTHONUNBUFFERED"] = "1"
+            snakemake_path = _find_tool("snakemake")
             env_bin = str(Path(sys.executable).parent)
-            if env_bin not in env.get("PATH", ""):
-                env["PATH"] = env_bin + os.pathsep + env.get("PATH", "")
+            extra_dirs = [env_bin]
+            if snakemake_path:
+                extra_dirs.append(str(Path(snakemake_path).parent))
+            for d in extra_dirs:
+                if d and d not in env.get("PATH", ""):
+                    env["PATH"] = d + os.pathsep + env.get("PATH", "")
 
             proc = subprocess.run(
                 eval_cmd,

--- a/gui/snakefile_builder.py
+++ b/gui/snakefile_builder.py
@@ -62,14 +62,21 @@ def build_params_txt(params: dict) -> str:
         (
             "## Parameters in generating primers",
             [
-                "MAX_PRIMER_CANDIDATES",
                 "TM_MIN",
                 "TM_MAX",
                 "GC_MAX",
                 "DG_MIN",
                 "PRIMER_LEN_MIN",
                 "PRIMER_LEN_MAX",
-                "TILING_STEP",
+                "QUICK_N_POSITIONS",
+                "QUICK_N_VARIANTS",
+            ],
+        ),
+        (
+            "## Target thresholds for early stopping",
+            [
+                "QUICK_COV_MIN",
+                "QUICK_ACT_MIN",
             ],
         ),
         (
@@ -87,6 +94,7 @@ def build_params_txt(params: dict) -> str:
             "## Probe mode configuration (singleplex only)",
             [
                 "PROBE_MAX_MISMATCHES",
+                "PROBE_MAX_INDELS",
                 "PROBE_AMPLICON_BUFFER",
                 "MIN_PROBES_PER_PAIR",
                 "MAX_PROBES_PER_PAIR",

--- a/src/qprimer_designer/cli.py
+++ b/src/qprimer_designer/cli.py
@@ -51,6 +51,7 @@ For more information on a specific command:
         build_output,
         select_multiplex,
         export_report,
+        quick_design,
     )
 
     generate.register(subparsers)
@@ -65,6 +66,7 @@ For more information on a specific command:
     build_output.register(subparsers)
     select_multiplex.register(subparsers)
     export_report.register(subparsers)
+    quick_design.register(subparsers)
 
     args = parser.parse_args()
 

--- a/src/qprimer_designer/commands/build_output.py
+++ b/src/qprimer_designer/commands/build_output.py
@@ -147,7 +147,8 @@ def extract_amplicon_sequences(final, eval_full_path, ref_path):
 
     if not os.path.exists(eval_full_path) or os.path.getsize(eval_full_path) == 0:
         print(f"Warning: {eval_full_path} not found or empty, skipping amplicon extraction")
-        return pd.Series("", index=final.index)
+        empty = pd.Series("", index=final.index)
+        return empty, empty.copy(), empty.copy()
 
     full_df = pd.read_csv(eval_full_path)
     # Filter to high-confidence predictions
@@ -281,6 +282,7 @@ def run(args):
         merged.loc[(fname, rname), "pseq_r"] = rseq
 
     final = merged.copy()
+    probe_seqs_dict = {}
 
     # PROBE MODE: Add probe information and optionally filter by off-target amplicon overlap
     if args.probe_mapping_on and args.probe_seqs:
@@ -348,23 +350,19 @@ def run(args):
                 for pair_key in final.index
             }
 
-        # Add probe information to final DataFrame
-        final['valid_probes'] = final.index.map(lambda p: ','.join(valid_probes_dict.get(p, [])))
-        final['valid_probe_sequences'] = final.index.map(
-            lambda p: ','.join([probe_seqs_dict[pname] for pname in valid_probes_dict.get(p, []) if pname in probe_seqs_dict])
+        # Store all valid probes per pair (greedy assignment happens after sorting)
+        final['_all_valid_probes'] = final.index.map(
+            lambda p: valid_probes_dict.get(p, [])
         )
-
-        print(f"Probe filtering complete. Pairs with valid probes: {(final['valid_probe_sequences'].str.len() > 0).sum()}")
+        n_with_probes = sum(1 for probes in final['_all_valid_probes'] if probes)
+        print(f"Probe filtering complete. Pairs with valid probes: {n_with_probes}")
 
     # Extract amplicon sequences if reference provided
     if args.ref:
         eval_full_path = f"{args.eval_on}.full"
         amp_seqs, fwd_pos, rev_pos = extract_amplicon_sequences(final, eval_full_path, args.ref)
-        final['amplicon_seq'] = amp_seqs
         final['approx_fwd_start'] = fwd_pos
         final['approx_rev_start'] = rev_pos
-        n_with_amplicon = (final['amplicon_seq'].str.len() > 0).sum()
-        print(f"Extracted amplicon sequences for {n_with_amplicon}/{len(final)} pairs")
 
     # Sort by sum of off-target scores (ascending - lower is better)
     offtarget_score_cols = [col for col in final.columns if col.startswith('sco_') and col != 'sco_target']
@@ -373,6 +371,31 @@ def run(args):
         final = final.sort_values('offtarget_score_sum')
         print(f"Sorted by sum of off-target scores")
 
+
+    # Greedy probe assignment: walk pairs in rank order, assign each the
+    # best unclaimed probe, drop pairs with no unclaimed probes left.
+    if '_all_valid_probes' in final.columns:
+        claimed_probes = set()
+        assigned_probe = {}
+        keep_idxs = []
+        for pair_key in final.index:
+            probes = final.at[pair_key, '_all_valid_probes']
+            if not probes:
+                continue
+            for p in probes:
+                if p not in claimed_probes:
+                    assigned_probe[pair_key] = p
+                    claimed_probes.add(p)
+                    keep_idxs.append(pair_key)
+                    break
+        n_before = len(final)
+        final = final.loc[keep_idxs].copy()
+        final['valid_probes'] = final.index.map(lambda p: assigned_probe.get(p, ''))
+        final['valid_probe_sequences'] = final['valid_probes'].map(
+            lambda p: probe_seqs_dict.get(p, '') if p else ''
+        )
+        final = final.drop(columns=['_all_valid_probes'])
+        print(f"Greedy probe assignment: {n_before} → {len(final)} pairs")
 
     # Convert coverage columns from numbers to "N / total" strings
     if args.ref:

--- a/src/qprimer_designer/commands/export_report.py
+++ b/src/qprimer_designer/commands/export_report.py
@@ -38,6 +38,12 @@ Creates one Excel file per primer set with:
     parser.add_argument("--ref", default=None, help="On-target reference FASTA (for counting total sequences)")
     parser.add_argument("--probe-max-mismatches", type=int, default=2,
                         help="Maximum mismatches for probe to count as matched (default: 2)")
+    parser.add_argument("--probe-max-indels", type=int, default=0,
+                        help="Maximum indels for probe to count as matched (default: 0)")
+    parser.add_argument("--mapped-on", default=None,
+                        help="On-target .mapped file (for probe alignment display)")
+    parser.add_argument("--mapped-off", nargs="*", default=[],
+                        help="Off-target .mapped files (for probe alignment display)")
     parser.set_defaults(func=run)
 
 
@@ -140,34 +146,53 @@ def eval_to_target_df(eval_path, pid, eval_type="on"):
     return df
 
 
-def annotate_probe(df, probe_mapping_path, pid, max_mismatches=2):
-    """
-    Add probe, mm_p, and indel_p columns to detail dataframe.
+def load_probe_mapped(mapped_path, pid):
+    """Load probe rows from a .mapped file for a given primer set ID.
 
-    probe = 1 if probe aligns within amplicon AND mismatches <= max_mismatches AND indels == 0.
+    Returns a DataFrame with columns:
+        target_id, start_pos, pseq, tseq, match, mismatches, indels
+    """
+    if not mapped_path or not Path(mapped_path).exists():
+        return pd.DataFrame()
+
+    probe_name = f"{pid}_pro"
+    cols = ['pname', 'orientation', 'tname', 'start', 'pseq', 'tseq', 'match']
+    raw = pd.read_table(mapped_path, sep='\t', names=cols)
+    raw = raw[raw['pname'] == probe_name].copy()
+    if raw.empty:
+        return pd.DataFrame()
+
+    # Compute mismatches and indels from alignment strings
+    raw['indels'] = raw['pseq'].str.count('-') + raw['tseq'].str.count('-')
+    raw['mismatches'] = (
+        raw['pseq'].str.len() - raw['match'].str.count(r'\|') - raw['indels']
+    )
+    # Convert to 0-based start position
+    raw['start_pos'] = raw['start'] - 1
+
+    return raw.rename(columns={'tname': 'target_id'})[
+        ['target_id', 'start_pos', 'pseq', 'tseq', 'match', 'mismatches', 'indels']
+    ].reset_index(drop=True)
+
+
+def annotate_probe(df, mapped_path, pid, max_mismatches=2, max_indels=0):
+    """
+    Add probe, mm_p, indel_p, and probe alignment columns to detail dataframe.
+
+    Reads probe rows directly from the .mapped file.
+    probe = 1 if probe aligns within amplicon AND mismatches <= max_mismatches AND indels <= max_indels.
     mm_p = mismatch count (substitutions only, recorded whenever probe is within amplicon).
     indel_p = indel count (recorded whenever probe is within amplicon).
+    align_p = formatted probe-target alignment string.
     """
     df["probe"] = 0
     df["mm_p"] = np.nan
     df["indel_p"] = np.nan
+    df["align_p"] = ""
 
-    if probe_mapping_path is None:
-        return df
-
-    probe_df = pd.read_csv(probe_mapping_path)
+    probe_df = load_probe_mapped(mapped_path, pid)
     if probe_df.empty:
         return df
-
-    # Filter to probes matching this primer set
-    probe_name = f"{pid}_pro"
-    probe_df = probe_df[probe_df["probe_name"] == probe_name]
-    if probe_df.empty:
-        return df
-
-    # Ensure indels column exists (backward compatibility)
-    if "indels" not in probe_df.columns:
-        probe_df["indels"] = 0
 
     # Reset index to avoid duplicate index issues, then restore
     df = df.reset_index()
@@ -181,15 +206,26 @@ def annotate_probe(df, probe_mapping_path, pid, max_mismatches=2):
         hits = probe_df[probe_df["target_id"] == seq_id]
         for _, hit in hits.iterrows():
             probe_start = hit["start_pos"]
-            probe_end = probe_start + len(hit["probe_seq"])
+            probe_end = probe_start + len(hit["pseq"].replace("-", ""))
             # Probe is within amplicon if it's fully contained
             if probe_start >= amp_start and probe_end <= amp_end:
                 mm = hit["mismatches"]
                 indel = hit["indels"]
                 df.at[i, "mm_p"] = mm
                 df.at[i, "indel_p"] = indel
-                if mm <= max_mismatches and indel == 0:
+                if mm <= max_mismatches and indel <= max_indels:
                     df.at[i, "probe"] = 1
+                # Build alignment string
+                pseq = hit["pseq"]
+                tseq = hit["tseq"]
+                match = hit["match"]
+                p_len = len(pseq.replace("-", ""))
+                p_end = probe_start + p_len - 1
+                df.at[i, "align_p"] = (
+                    f"1     {pseq}{str(p_len).rjust(6)}\n"
+                    f"      {match}      \n"
+                    f"{str(probe_start).ljust(6)}{tseq}{str(p_end).rjust(6)}"
+                )
                 break
 
     df["probe"] = df["probe"].astype(int)
@@ -521,9 +557,14 @@ def run(args):
     print(f"Output directory: {outdir}")
     print(f"Primer sets to evaluate: {', '.join(args.names)}")
 
-    has_probe = args.probe_mapping_on is not None
+    has_probe = args.mapped_on is not None or args.probe_mapping_on is not None
+    mapped_on = args.mapped_on
     probe_mapping_on = args.probe_mapping_on
     probe_max_mm = args.probe_max_mismatches
+    probe_max_indel = args.probe_max_indels
+    mapped_off = {
+        get_target_name(p): p for p in args.mapped_off
+    } if args.mapped_off else {}
     probe_mapping_off = {
         get_target_name(p): p for p in args.probe_mapping_off
     } if args.probe_mapping_off else {}
@@ -551,6 +592,9 @@ def run(args):
     ]
 
     if has_probe:
+        # Insert align_p right after align_r
+        idx = cols.index("align_r") + 1
+        cols.insert(idx, "align_p")
         cols += ["probe", "mm_p", "indel_p"]
 
     for pid in args.names:
@@ -567,7 +611,8 @@ def run(args):
             df_on["eval_type"] = "on"
             df_on["target"] = get_target_name(args.on)
             if has_probe:
-                df_on = annotate_probe(df_on, probe_mapping_on, pid, probe_max_mm)
+                probe_src = mapped_on or probe_mapping_on
+                df_on = annotate_probe(df_on, probe_src, pid, probe_max_mm, probe_max_indel)
             # Add unmapped sequences from reference
             df_on = add_unmapped_rows(df_on, ref_seq_ids)
             df_on = add_decision_columns(df_on, has_probe)
@@ -598,8 +643,8 @@ def run(args):
                     df_off["eval_type"] = "off"
                     df_off["target"] = target_name
                     if has_probe:
-                        off_probe_path = probe_mapping_off.get(target_name)
-                        df_off = annotate_probe(df_off, off_probe_path, pid, probe_max_mm)
+                        off_src = mapped_off.get(target_name) or probe_mapping_off.get(target_name)
+                        df_off = annotate_probe(df_off, off_src, pid, probe_max_mm, probe_max_indel)
                     df_off = add_decision_columns(df_off, has_probe)
                     dfs.append(df_off[cols].sort_values("regressor", ascending=False))
                 else:

--- a/src/qprimer_designer/commands/filter_primers.py
+++ b/src/qprimer_designer/commands/filter_primers.py
@@ -2,6 +2,7 @@
 
 import argparse
 import ast
+import os
 from collections import defaultdict
 
 import pandas as pd
@@ -13,7 +14,17 @@ from qprimer_designer.external import compute_batch_dimer_dg
 
 def load_probe_data(probe_mapping_path, probe_seqs_path):
     """Load probe mapping table and sequences, with pre-built indexes."""
-    mapping_df = pd.read_csv(probe_mapping_path)
+    import os
+    # Handle empty probe files (e.g., no probes passed filters)
+    if (os.path.getsize(probe_mapping_path) == 0 or
+            os.path.getsize(probe_seqs_path) == 0):
+        return {}, {}, {}, {}, {}
+    try:
+        mapping_df = pd.read_csv(probe_mapping_path)
+    except pd.errors.EmptyDataError:
+        return {}, {}, {}, {}, {}
+    if mapping_df.empty:
+        return {}, {}, {}, {}, {}
     probe_seqs = {rec.id: str(rec.seq) for rec in SeqIO.parse(probe_seqs_path, "fasta")}
 
     # Build dict indexes for O(1) lookups instead of repeated DataFrame filtering
@@ -178,6 +189,22 @@ def run(args):
     # Load primer sequences
     primer_seqs = {rec.id: str(rec.seq) for rec in SeqIO.parse(args.init, "fasta")}
 
+    # Filter out pairs with very low coverage before any further processing
+    min_coverage = float(params.get("COVERAGE_MIN", 0.5))
+    n_before = len(res)
+    res = res[res['coverage'] >= min_coverage].reset_index(drop=True)
+    if len(res) < n_before:
+        print(f"Filtered {n_before - len(res)}/{n_before} pairs below coverage threshold ({min_coverage})")
+
+    if res.empty:
+        print(f"Warning: No pairs above coverage threshold ({min_coverage}), writing empty output")
+        open(args.out, "w").close()
+        csv_out = args.out.replace(".fa", ".csv")
+        open(csv_out, "w").close()
+        if args.probe_out:
+            open(args.probe_out, "w").close()
+        return
+
     # PROBE MODE
     if args.probe_mapping and args.probe_seqs:
         print("Probe mode enabled - filtering by probe compatibility...")
@@ -194,20 +221,30 @@ def run(args):
         max_mismatches = int(params.get("PROBE_MAX_MISMATCHES", 2))
 
         # Load .full file for ALL pairs (probe compatibility checked first)
+        # Quick design writes .eval.full but positions use windowed coordinates
+        # that don't match probe mapping positions — skip position validation
+        # (probe-primer compatibility was already checked during quick design)
         eval_full_path = f"{args.scores}.full"
+        is_quick_design = os.path.exists(f"{args.scores}.quick")
+        has_full_file = (
+            os.path.exists(eval_full_path)
+            and os.path.getsize(eval_full_path) > 0
+            and not is_quick_design
+        )
 
         all_pairs_set = set(zip(res['pname_f'], res['pname_r']))
 
         pair_full_data = {}
-        for chunk in pd.read_csv(eval_full_path, chunksize=10000):
-            for _, row in chunk.iterrows():
-                pair_key = (row['pname_f'], row['pname_r'])
-                if row.get('classifier', 1.0) < 0.5:
-                    continue
-                if pair_key in all_pairs_set:
-                    if pair_key not in pair_full_data:
-                        pair_full_data[pair_key] = []
-                    pair_full_data[pair_key].append(row)
+        if has_full_file:
+            for chunk in pd.read_csv(eval_full_path, chunksize=10000):
+                for _, row in chunk.iterrows():
+                    pair_key = (row['pname_f'], row['pname_r'])
+                    if row.get('classifier', 1.0) < 0.5:
+                        continue
+                    if pair_key in all_pairs_set:
+                        if pair_key not in pair_full_data:
+                            pair_full_data[pair_key] = []
+                        pair_full_data[pair_key].append(row)
 
         print(f"Checking {len(res)} pairs for probe compatibility (before top-N selection)...")
 
@@ -221,19 +258,25 @@ def run(args):
             pname_r = row['pname_r']
             pair_key = (pname_f, pname_r)
 
-            if pair_key not in pair_full_data:
-                continue
+            if has_full_file:
+                # Standard mode: validate probe positions within amplicons
+                if pair_key not in pair_full_data:
+                    continue
 
-            candidates = _find_position_valid_probes(
-                pair_full_data[pair_key],
-                probes_by_target,
-                probe_positions,
-                probe_mismatches,
-                probe_indels,
-                probe_seqs_dict,
-                buffer,
-                max_mismatches,
-            )
+                candidates = _find_position_valid_probes(
+                    pair_full_data[pair_key],
+                    probes_by_target,
+                    probe_positions,
+                    probe_mismatches,
+                    probe_indels,
+                    probe_seqs_dict,
+                    buffer,
+                    max_mismatches,
+                )
+            else:
+                # Quick design mode: all mapped probes are candidates
+                # (position validation was done during quick design)
+                candidates = list(probe_seqs_dict.keys())
 
             if not candidates:
                 continue
@@ -258,7 +301,8 @@ def run(args):
                 all_dg = compute_batch_dimer_dg(all_dimer_pairs)
             except Exception as e:
                 print(f"Warning: Batch dimer computation failed: {e}")
-                all_dg = [None] * len(all_dimer_pairs)
+                print("  Skipping dimer filter — all probes will be kept.")
+                all_dg = [0.0] * len(all_dimer_pairs)
 
         # Phase 3: distribute results and filter by ΔG threshold
         valid_pairs = []
@@ -301,7 +345,7 @@ def run(args):
                 axis=1
             )
             top['probe_names'] = top.apply(
-                lambda r: ','.join(valid_probes_per_pair.get((r['pname_f'], r['pname_r']), [])[:max_probes]),
+                lambda r: ','.join(valid_probes_per_pair.get((r['pname_f'], r['pname_r']), [])),
                 axis=1
             )
 
@@ -314,7 +358,7 @@ def run(args):
                     continue
                 pname_f, pname_r = pair_key
                 pair_probes = valid_probes_per_pair[pair_key]
-                for probe_name in pair_probes[:max_probes]:
+                for probe_name in pair_probes:
                     probe_assignments.append({
                         'pname_f': pname_f,
                         'pname_r': pname_r,
@@ -324,7 +368,7 @@ def run(args):
 
             probe_df = pd.DataFrame(probe_assignments)
             probe_df.to_csv(args.probe_out, index=False)
-            print(f"Wrote {len(probe_df)} probe assignments to {args.probe_out} (max {max_probes} per pair)")
+            print(f"Wrote {len(probe_df)} probe assignments to {args.probe_out}")
 
             # Write probe FASTA with unique probes from limited set
             probe_fasta_out = args.probe_out.replace(".csv", ".fa")

--- a/src/qprimer_designer/commands/generate.py
+++ b/src/qprimer_designer/commands/generate.py
@@ -12,7 +12,7 @@ from Bio import SeqIO
 from Bio.SeqUtils import gc_fraction
 
 from qprimer_designer.utils import reverse_complement_dna, get_tm, parse_params, get_primer_params, sanitize_iupac
-from qprimer_designer.external import compute_self_dimer_dg
+from qprimer_designer.external import compute_batch_dimer_dg
 
 
 def register(subparsers):
@@ -81,10 +81,21 @@ def generate_primers_multi(
     max_gc: float,
     min_dg: float,
 ):
-    """Generate and filter primer candidates across multiple target sequences."""
+    """Generate and filter primer candidates across multiple target sequences.
+
+    Returns (for_filt, rev_filt, features) where features[seq] includes
+    a 'rep_count' key indicating how many input sequences produced that primer.
+    """
     forps, revps = {}, {}
+    # Track how many target sequences each primer appears in
+    fwd_counts = defaultdict(int)
+    rev_counts = defaultdict(int)
     for tseq in target_seqs:
         flist, rlist = generate_primers_single(tseq, step, min_pri_len, max_pri_len, min_amp_len)
+        for seq in flist:
+            fwd_counts[seq] += 1
+        for seq in rlist:
+            rev_counts[seq] += 1
         forps.update(flist)
         revps.update(rlist)
 
@@ -94,22 +105,30 @@ def generate_primers_multi(
     for_filt, rev_filt = {}, {}
     features = defaultdict(dict)
 
-    for unfilt, filt in zip([forps, revps], [for_filt, rev_filt]):
+    for unfilt, filt, counts in zip([forps, revps], [for_filt, rev_filt], [fwd_counts, rev_counts]):
+        # First pass: filter by Tm and GC (fast)
+        tm_gc_passed = {}
         for pseq in unfilt:
-            # Calculate features
+            if len(pseq) < 2:
+                continue
             tm = get_tm(pseq)
             gc = gc_fraction(pseq)
-
-            # Filter by Tm and GC
             if min_tm <= tm <= max_tm and gc <= max_gc / 100.0:
-                dG = compute_self_dimer_dg(pseq)
+                tm_gc_passed[pseq] = (tm, gc)
 
-                # Only add features if all filters pass
+        # Batch dG computation (single subprocess call)
+        if tm_gc_passed:
+            pairs = [(pseq, pseq) for pseq in tm_gc_passed]
+            dg_values = compute_batch_dimer_dg(pairs)
+
+            for (pseq, _), dG in zip(pairs, dg_values):
                 if dG >= min_dg:
+                    tm, gc = tm_gc_passed[pseq]
                     features[pseq]["Tm"] = round(tm, 1)
                     features[pseq]["GC"] = round(gc, 2)
                     features[pseq]["len"] = len(pseq)
                     features[pseq]["dG"] = round(dG, 1)
+                    features[pseq]["rep_count"] = counts.get(pseq, 1)
                     filt[pseq] = unfilt[pseq]
 
     valid_pairs = count_primer_pairs(for_filt, rev_filt, min_amp_len, max_amp_len)

--- a/src/qprimer_designer/commands/generate_probe.py
+++ b/src/qprimer_designer/commands/generate_probe.py
@@ -11,7 +11,7 @@ from Bio import SeqIO
 from Bio.SeqUtils import gc_fraction
 
 from qprimer_designer.utils import get_tm, parse_params, get_probe_params, reverse_complement_dna, has_homopolymer, sanitize_iupac
-from qprimer_designer.external import compute_self_dimer_dg
+from qprimer_designer.external import compute_batch_dimer_dg
 
 
 def register(subparsers):
@@ -96,25 +96,28 @@ def generate_probes(
     filtered = {}
     features = defaultdict(dict)
 
+    # First pass: fast filters (5' G, homopolymer, Tm, GC)
+    tm_gc_passed = {}
     for pseq in probes:
-        # Check 5' G constraint
         if avoid_5prime_G and pseq[0] == 'G':
             continue
-
-        # Check homopolymer
         if has_homopolymer(pseq, homopolymer_max):
             continue
 
-        # Calculate features
         tm = get_tm(pseq)
         gc = gc_fraction(pseq)
 
-        # Filter by Tm and GC
         if min_tm <= tm <= max_tm and gc <= max_gc / 100.0:
-            dG = compute_self_dimer_dg(pseq)
+            tm_gc_passed[pseq] = (tm, gc)
 
-            # Only add features if all filters pass
+    # Batch dG computation (single subprocess call)
+    if tm_gc_passed:
+        pairs = [(pseq, pseq) for pseq in tm_gc_passed]
+        dg_values = compute_batch_dimer_dg(pairs)
+
+        for (pseq, _), dG in zip(pairs, dg_values):
             if dG >= min_dg:
+                tm, gc = tm_gc_passed[pseq]
                 features[pseq]["Tm"] = round(tm, 1)
                 features[pseq]["GC"] = round(gc, 2)
                 features[pseq]["len"] = len(pseq)

--- a/src/qprimer_designer/commands/pick_representatives.py
+++ b/src/qprimer_designer/commands/pick_representatives.py
@@ -36,6 +36,8 @@ for downstream primer design using MinHash-based approximate clustering.
     parser.add_argument("--name", required=True, help="Target name")
     parser.add_argument("--probe-regions", dest="probe_regions", default=None,
                        help="Output TSV of conserved probe regions (optional)")
+    parser.add_argument("--window-seqs", dest="window_seqs", default=None,
+                       help="Output FASTA of ALL sequences trimmed to the design window (optional)")
     parser.set_defaults(func=run)
 
 
@@ -196,27 +198,112 @@ class NearNeighborLookup:
 
 # --- Clustering logic ---
 
-def find_low_gap_window(seqs, window_size=200):
-    """Find window position with minimum gap content."""
+def _column_entropy(seqs, col_idx):
+    """Compute Shannon entropy for a single MSA column (ignoring gaps)."""
+    bases = [s[col_idx].upper() for s in seqs if s[col_idx] != '-']
+    if not bases:
+        return 0.0
+    n = len(bases)
+    counts = {}
+    for b in bases:
+        counts[b] = counts.get(b, 0) + 1
+    ent = 0.0
+    for c in counts.values():
+        p = c / n
+        if p > 0:
+            ent -= p * np.log2(p)
+    return ent
+
+
+def find_best_design_window(seqs, window_size=500, primer_len=20, min_gc=0.35):
+    """Find window position that maximizes conservation-weighted primer coverage.
+
+    For each column, compute: gap-free fraction × identity fraction.
+    This rewards positions where many sequences are gap-free AND share the
+    same base. For each primer position (primer_len bp), the score is the
+    mean of these per-column scores. The design window score is the sum
+    across all primer positions in the window.
+
+    Only considers windows where the consensus GC content >= min_gc.
+    Falls back to no GC filter if no window passes.
+    """
     if not seqs:
         return 0
 
     seq_len = len(seqs[0])
-    best_pos = 0
-    min_gaps = float('inf')
+    n_seqs = len(seqs)
 
-    # BUG FIX: Off-by-one error - original code missed the last valid window position.
-    # For a 30bp sequence with window_size=20, last valid position is 10 (0-indexed).
-    # Original range(0, 10) checked 0-9, missing position 10.
-    # Fixed range(0, 11) checks 0-10 (all valid positions).
-    # Original:
-    # for pos in range(0, max(1, seq_len - window_size)):
-    for pos in range(0, max(1, seq_len - window_size + 1)):
-        gaps = sum(s[pos:pos + window_size].count('-') for s in seqs)
-        if gaps < min_gaps:
-            min_gaps = gaps
-            best_pos = pos
+    # Pre-compute per-column gap/N flags as numpy array (n_seqs x seq_len)
+    gap_matrix = np.array([[c in ('-', 'N', 'n') for c in s] for s in seqs], dtype=np.int8)
 
+    # Per-column conservation-weighted score:
+    # gap_free_frac × identity_frac (both relative to n_seqs)
+    from collections import Counter as _Counter
+    col_scores = np.zeros(seq_len, dtype=np.float64)
+    consensus = []
+    for col in range(seq_len):
+        col_bases = [s[col].upper() for s in seqs if s[col] not in ('-', 'N', 'n')]
+        if col_bases:
+            cnt = _Counter(col_bases)
+            most_common_count = cnt.most_common(1)[0][1]
+            consensus.append(cnt.most_common(1)[0][0])
+            gap_free_frac = len(col_bases) / n_seqs
+            identity_frac = most_common_count / len(col_bases)
+            col_scores[col] = gap_free_frac * identity_frac
+        else:
+            consensus.append('N')
+            col_scores[col] = 0.0
+
+    # For each primer position, compute mean col_score across primer_len columns
+    max_primer_start = seq_len - primer_len + 1
+    if max_primer_start <= 0:
+        return 0
+
+    cum_col = np.concatenate([[0.0], np.cumsum(col_scores)])
+    primer_scores = (cum_col[primer_len:max_primer_start + primer_len] -
+                     cum_col[:max_primer_start]) / primer_len  # shape: (max_primer_start,)
+
+    # Score each design window by sum of primer_scores
+    n_primer_positions = window_size - primer_len + 1
+    if n_primer_positions <= 0:
+        return 0
+
+    cum_ps = np.concatenate([[0.0], np.cumsum(primer_scores)])
+    max_window_start = min(max_primer_start - n_primer_positions + 1, seq_len - window_size + 1)
+    if max_window_start <= 0:
+        return 0
+
+    window_scores = cum_ps[n_primer_positions:max_window_start + n_primer_positions] - cum_ps[:max_window_start]
+
+    # GC filtering
+    gc_arr = np.array([1.0 if b in 'GC' else 0.0 for b in consensus])
+    cum_gc = np.concatenate([[0.0], np.cumsum(gc_arr)])
+
+    # Find best window with GC filter
+    best_score = -1.0
+    best_pos = -1
+    best_gc = 0.0
+    for w in range(max_window_start):
+        gc = (cum_gc[w + window_size] - cum_gc[w]) / window_size
+        if gc < min_gc:
+            continue
+        score = window_scores[w]
+        if score > best_score:
+            best_score = score
+            best_pos = w
+            best_gc = gc
+
+    max_possible = n_primer_positions  # each primer position can score at most 1.0
+    if best_pos >= 0:
+        print(f"  Design window: pos {best_pos}, conservation score {best_score:.1f}/{max_possible}, GC={best_gc:.3f}")
+        return best_pos
+
+    # Fallback: no GC filter
+    best_pos = int(np.argmax(window_scores))
+    best_score = window_scores[best_pos]
+    fb_gc = (cum_gc[best_pos + window_size] - cum_gc[best_pos]) / window_size
+    print(f"  WARNING: No window with GC>={min_gc}. Fallback: pos {best_pos}, "
+          f"conservation score {best_score:.1f}/{max_possible}, GC={fb_gc:.3f}")
     return best_pos
 
 
@@ -375,8 +462,8 @@ def select_medoids(seqs, clusters, signatures, family):
 def run(args):
     """Run the pick-representatives command."""
     params = parse_params(args.param_file)
-    num_reps = int(params.get("NUM_REPRESENTATIVE_SEQS", 5))
-    window_size = int(params.get("DESIGN_WINDOW", 200))
+    min_cluster_frac = float(params.get("MIN_CLUSTER_FRAC", 0.05))
+    window_size = int(params.get("DESIGN_WINDOW", 500))
     kmer_size = int(params.get("MINHASH_KMER_SIZE", 10))
 
     print(f"Selecting representative sequences from {args.input}...")
@@ -387,30 +474,44 @@ def run(args):
     seqs = [str(r.seq) for r in records]
     names = [r.id for r in records]
 
-    if len(seqs) <= num_reps:
-        # Fewer sequences than requested representatives - return all
+    primer_len = int(params.get("PRIMER_LEN_MIN", 20))
+
+    if len(seqs) <= 2:
+        # Fewer sequences than requested representatives - return all (window-trimmed)
+        window_start = find_best_design_window(seqs, window_size, primer_len)
+        trimmed = trim_to_window(seqs, window_start, window_size)
         with open(args.output, "w") as out:
-            for r in records:
-                out.write(f">{r.id}\n{str(r.seq).replace('-', '')}\n")
+            for r, t in zip(records, trimmed):
+                out.write(f">{r.id}\n{t}\n")
         # Write empty probe regions (no MSA-based filtering needed)
         if getattr(args, 'probe_regions', None):
             with open(args.probe_regions, "w") as f:
                 f.write("start\tend\tnum_variable_sites\n")
-        print(f"Wrote {len(seqs)} sequences (all) to {args.output}")
+        # Window seqs = same as output when all seqs are representatives
+        if getattr(args, 'window_seqs', None):
+            with open(args.window_seqs, "w") as out:
+                for r, t in zip(records, trimmed):
+                    out.write(f">{r.id}\n{t}\n")
+        print(f"Wrote {len(seqs)} sequences (all, window-trimmed) to {args.output}")
         return
 
-    # Find low-gap window and trim
-    window_start = find_low_gap_window(seqs, window_size)
+    # Find best design window and trim
+    window_start = find_best_design_window(seqs, window_size, primer_len)
     trimmed = trim_to_window(seqs, window_start, window_size)
 
-    # Filter out empty sequences
-    valid_indices = [i for i, s in enumerate(trimmed) if len(s) >= kmer_size]
+    # Filter out empty sequences and N-rich sequences (>10% N)
+    def _is_valid_trimmed(s):
+        if len(s) < kmer_size:
+            return False
+        n_count = s.upper().count('N')
+        return n_count / len(s) <= 0.1
+    valid_indices = [i for i, s in enumerate(trimmed) if _is_valid_trimmed(s)]
     if not valid_indices:
-        # Fall back to first num_reps sequences
+        # Fall back to first num_reps sequences (window-trimmed)
         with open(args.output, "w") as out:
             for i in range(min(num_reps, len(records))):
                 r = records[i]
-                out.write(f">{r.id}\n{str(r.seq).replace('-', '')}\n")
+                out.write(f">{r.id}\n{trimmed[i]}\n")
         if getattr(args, 'probe_regions', None):
             with open(args.probe_regions, "w") as f:
                 f.write("start\tend\tnum_variable_sites\n")
@@ -419,26 +520,107 @@ def run(args):
 
     valid_trimmed = [trimmed[i] for i in valid_indices]
 
+    # Subsample if too many sequences for O(n²) clustering
+    MAX_CLUSTER_SEQS = 500
+    if len(valid_trimmed) > MAX_CLUSTER_SEQS:
+        rng = random.Random(42)
+        sample_local = sorted(rng.sample(range(len(valid_trimmed)), MAX_CLUSTER_SEQS))
+        sampled_trimmed = [valid_trimmed[i] for i in sample_local]
+        sampled_valid_indices = [valid_indices[i] for i in sample_local]
+        print(f"  Subsampled {len(valid_trimmed)} -> {MAX_CLUSTER_SEQS} sequences for clustering")
+    else:
+        sampled_trimmed = valid_trimmed
+        sampled_valid_indices = valid_indices
+
     # Cluster and select medoids
     family = MinHashFamily(kmer_size=kmer_size, N=100)
     h = family.make_h()
-    signatures = [h(s) for s in valid_trimmed]
+    signatures = [h(s) for s in sampled_trimmed]
 
-    clusters = cluster_sequences(valid_trimmed, kmer_size=kmer_size)
-    medoid_local = select_medoids(valid_trimmed, clusters, signatures, family)
+    clusters = cluster_sequences(sampled_trimmed, kmer_size=kmer_size)
+    medoid_local = select_medoids(sampled_trimmed, clusters, signatures, family)
+
+    # Compute cluster sizes and fractions
+    from collections import Counter as _Counter
+    cluster_sizes = _Counter(clusters)
+    total_seqs_clustered = len(clusters)
+
+    # Map medoid local index → cluster label → fraction
+    medoid_cluster_frac = {}
+    for ml in medoid_local:
+        cluster_label = clusters[ml]
+        frac = cluster_sizes[cluster_label] / total_seqs_clustered
+        medoid_cluster_frac[ml] = round(frac, 4)
 
     # Map back to original indices
-    medoid_indices = [valid_indices[i] for i in medoid_local]
+    medoid_indices = [sampled_valid_indices[i] for i in medoid_local]
 
-    # Limit to num_reps
-    if len(medoid_indices) > num_reps:
-        medoid_indices = medoid_indices[:num_reps]
+    # Sort medoids by cluster size (largest first)
+    sorted_pairs = sorted(
+        zip(medoid_local, medoid_indices),
+        key=lambda pair: medoid_cluster_frac[pair[0]],
+        reverse=True,
+    )
+    medoid_local = [p[0] for p in sorted_pairs]
+    medoid_indices = [p[1] for p in sorted_pairs]
 
-    # Write output
+    # Select medoids whose cluster represents >= min_cluster_frac of sequences
+    selected_ml = []
+    selected_idx = []
+    excluded = []
+    for ml, oi in zip(medoid_local, medoid_indices):
+        frac = medoid_cluster_frac[ml]
+        if frac >= min_cluster_frac:
+            selected_ml.append(ml)
+            selected_idx.append(oi)
+        else:
+            excluded.append((records[oi].id, frac))
+    # Always keep at least 1 medoid (the largest cluster)
+    if not selected_ml:
+        selected_ml = [medoid_local[0]]
+        selected_idx = [medoid_indices[0]]
+    medoid_local = selected_ml
+    medoid_indices = selected_idx
+
+    total_coverage = sum(medoid_cluster_frac[ml] for ml in medoid_local)
+
+    # Print cluster info
+    print(f"  Clusters: {len(cluster_sizes)}, selected {len(medoid_indices)} medoids "
+          f"(coverage={total_coverage:.4f}, threshold={min_cluster_frac})")
+    for ml, oi in zip(medoid_local, medoid_indices):
+        print(f"    {records[oi].id}: cluster_frac={medoid_cluster_frac[ml]:.4f}")
+    if excluded:
+        print(f"  Excluded {len(excluded)} small clusters (<{min_cluster_frac}):")
+        for name, frac in excluded:
+            print(f"    {name}: cluster_frac={frac:.4f}")
+
+    # Build consensus from design window (majority-rule, non-gap bases)
+    consensus_seq = []
+    for col in range(window_start, min(window_start + window_size, len(seqs[0]))):
+        bases = [s[col].upper() for s in seqs if s[col] not in ('-', 'N', 'n')]
+        if bases:
+            consensus_seq.append(_Counter(bases).most_common(1)[0][0])
+    consensus_seq = ''.join(consensus_seq)
+
+    # Write output (window-trimmed sequences, not full length)
+    # Medoids + consensus, with cluster_frac in header
     with open(args.output, "w") as out:
-        for i in medoid_indices:
+        for ml, i in zip(medoid_local, medoid_indices):
             r = records[i]
-            out.write(f">{r.id}\n{str(r.seq).replace('-', '')}\n")
+            frac = medoid_cluster_frac[ml]
+            out.write(f">{r.id} cluster_frac={frac}\n{trimmed[i]}\n")
+        out.write(f">{args.name}_consensus cluster_frac=0\n{consensus_seq}\n")
+
+    # Write ALL sequences trimmed to window (for bowtie2 indexing in quick mode)
+    # Include all non-empty sequences, not just valid_indices (no N% or length filter)
+    if getattr(args, 'window_seqs', None):
+        with open(args.window_seqs, "w") as out:
+            count = 0
+            for i, r in enumerate(records):
+                if len(trimmed[i]) > 0:
+                    out.write(f">{r.id}\n{trimmed[i]}\n")
+                    count += 1
+        print(f"Wrote {count} window-trimmed sequences to {args.window_seqs}")
 
     # Compute conserved probe regions if requested
     if getattr(args, 'probe_regions', None):
@@ -460,14 +642,15 @@ def run(args):
             print(f"Found {len(regions)} conserved probe region(s) covering {total_bp} bp")
         else:
             print(
-                f"[ERROR] No conserved probe regions found with current settings:\n"
+                f"[WARNING] No conserved probe regions found with current settings:\n"
                 f"  PROBE_CONSERVATION_THRESHOLD = {probe_params['conservation_threshold']}\n"
                 f"  PROBE_MAX_MISMATCHES = {probe_params['max_mismatches']}\n"
-                f"  Try lowering PROBE_CONSERVATION_THRESHOLD (e.g. 0.6) or "
+                f"  Probe design will be skipped for this target.\n"
+                f"  To enable probes, try lowering PROBE_CONSERVATION_THRESHOLD (e.g. 0.6) or "
                 f"increasing PROBE_MAX_MISMATCHES (e.g. 3-4) in params.txt.",
                 file=sys.stderr,
             )
-            sys.exit(1)
 
     runtime = time.time() - start_time
-    print(f"Wrote {len(medoid_indices)} representative sequences to {args.output} ({runtime:.1f} sec)")
+    n_written = len(medoid_indices) + 1  # medoids + consensus
+    print(f"Wrote {n_written} representative sequences ({len(medoid_indices)} medoids + 1 consensus) to {args.output} ({runtime:.1f} sec)")

--- a/src/qprimer_designer/commands/prepare_features.py
+++ b/src/qprimer_designer/commands/prepare_features.py
@@ -7,7 +7,7 @@ from Bio import SeqIO
 from Bio.SeqUtils import gc_fraction
 
 from qprimer_designer.utils import get_tm
-from qprimer_designer.external import compute_self_dimer_dg
+from qprimer_designer.external import compute_batch_dimer_dg
 
 
 def register(subparsers):
@@ -56,16 +56,21 @@ def run(args):
 
     print(f"Computing features for {len(records)} primers from {args.fa}...")
 
-    rows = []
+    # Compute all features, batch dG in a single subprocess
+    primer_data = []
     for rec in records:
         pname = rec.id
         pseq = str(rec.seq)
-
         forrev = infer_primer_orientation(pname)
         tm = get_tm(pseq)
         gc = gc_fraction(pseq)
-        dg = compute_self_dimer_dg(pseq)
+        primer_data.append((pname, pseq, forrev, tm, gc))
 
+    pairs = [(pseq, pseq) for _, pseq, _, _, _ in primer_data]
+    dg_values = compute_batch_dimer_dg(pairs)
+
+    rows = []
+    for (pname, pseq, forrev, tm, gc), dg in zip(primer_data, dg_values):
         rows.append({
             "pname": pname,
             "pseq": pseq,

--- a/src/qprimer_designer/commands/prepare_input.py
+++ b/src/qprimer_designer/commands/prepare_input.py
@@ -195,13 +195,13 @@ def run(args):
             r_starts_arr, r_ids_arr, r_lens_arr = rev_data
 
             # Binary search for candidate reverse primers
-            # amplicon_len = r_start + r_len - st_f + 1
+            # amplicon_len = r_start + r_len - st_f
             # Need: minl <= amplicon_len <= maxl
             # Use conservative bounds (min/max r_len) then exact-filter
             min_r_len = r_lens_arr[0] if len(r_lens_arr) == 1 else r_lens_arr.min()
             max_r_len = r_lens_arr[0] if len(r_lens_arr) == 1 else r_lens_arr.max()
-            lo_bound = st_f - 1 + minl - max_r_len
-            hi_bound = st_f - 1 + maxl - min_r_len
+            lo_bound = st_f + minl - max_r_len
+            hi_bound = st_f + maxl - min_r_len
 
             lo_idx = int(np.searchsorted(r_starts_arr, lo_bound, side='left'))
             hi_idx = int(np.searchsorted(r_starts_arr, hi_bound, side='right'))
@@ -213,7 +213,7 @@ def run(args):
             cand_starts = r_starts_arr[lo_idx:hi_idx]
             cand_ids = r_ids_arr[lo_idx:hi_idx]
             cand_lens = r_lens_arr[lo_idx:hi_idx]
-            amp_lens = cand_starts + cand_lens - st_f + 1
+            amp_lens = cand_starts + cand_lens - st_f
             valid_mask = (amp_lens >= minl) & (amp_lens <= maxl)
 
             if not valid_mask.any():

--- a/src/qprimer_designer/commands/quick_design.py
+++ b/src/qprimer_designer/commands/quick_design.py
@@ -1,0 +1,2527 @@
+"""Quick mode primer design with iterative batching and early stopping."""
+
+import argparse
+import ast
+import os
+import subprocess
+import time
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import torch
+from Bio import SeqIO
+from sklearn.preprocessing import MultiLabelBinarizer
+from torch.utils.data import DataLoader
+
+from Bio.SeqUtils import gc_fraction
+
+from qprimer_designer.commands.generate import generate_primers_multi, generate_primers_single
+from qprimer_designer.commands.prepare_input import run as run_prepare_input
+from qprimer_designer.external import compute_batch_dimer_dg
+from qprimer_designer.external.bowtie import build_index, find_bowtie2
+from qprimer_designer.models import load_models, PcrDataset, FEATURE_COLUMNS
+from qprimer_designer.utils import (
+    encode_batch_parallel,
+    get_tm,
+    has_homopolymer,
+    reverse_complement_dna,
+    parse_params,
+    get_primer_params,
+    get_probe_params,
+    sanitize_iupac,
+)
+
+
+def register(subparsers):
+    """Register the quick-design subcommand."""
+    parser = subparsers.add_parser(
+        "quick-design",
+        help="Quick primer design with iterative batching",
+        description="""
+Quick mode for primer design. Generates all primer candidates, then
+evaluates batches of ~100 pairs with early stopping when coverage and
+activity thresholds are met. Designed for multi-sequence targets where
+full pipeline would take too long.
+""",
+    )
+    parser.add_argument("--target", required=True, help="Original target FASTA (all sequences)")
+    parser.add_argument("--selected", default=None,
+                       help="Selected/representative target FASTA (required for single-window mode)")
+    parser.add_argument("--out", required=True, help="Output CSV path")
+    parser.add_argument("--params", dest="param_file", required=True, help="Parameters file")
+    parser.add_argument("--name", required=True, help="Target name")
+    parser.add_argument("--msa", default=None,
+                       help="Aligned MSA FASTA (enables multi-region amplicon scoring)")
+    parser.add_argument("--target-window", dest="target_window", default=None,
+                       help="Window-trimmed target FASTA (legacy single-window mode)")
+    parser.add_argument("--tmpdir", default=None,
+                       help="Directory for intermediate files (default: next to output CSV)")
+    parser.add_argument("--init-fa", dest="init_fa", default=None,
+                       help="Output FASTA with all evaluated primers (pipeline integration)")
+    parser.add_argument("--init-feat", dest="init_feat", default=None,
+                       help="Output features file for evaluated primers (pipeline integration)")
+    parser.add_argument("--probe-mode", dest="probe_mode", action="store_true",
+                       help="Enable probe-first design mode (find conserved probe regions first)")
+    parser.add_argument("--probe-fa", dest="probe_fa", default=None,
+                       help="Output FASTA for probe candidates (probe mode)")
+    parser.add_argument("--probe-feat", dest="probe_feat", default=None,
+                       help="Output features CSV for probe candidates (probe mode)")
+    parser.add_argument("--probe-csv", dest="probe_csv", default=None,
+                       help="Output probe mapping CSV (probe mode, replaces bowtie2 alignment)")
+    parser.add_argument("--threads", type=int, default=1, help="Number of threads")
+    parser.set_defaults(func=run)
+
+
+PRIMERS_PER_BATCH = 100  # primers per batch (fwd+rev combined)
+CONSENSUS_QUOTA_FRAC = 0.2  # consensus gets 20% of batch slots
+MAX_BATCHES = 5
+TOP_PAIRS = 1000  # top primer pairs to evaluate (after Tm/GC/dG filtering)
+N_POSITIONS = 100  # amplicon positions to score (multi-region mode)
+N_VARIANTS = 10   # primer variants per position per direction
+
+# Wobble tolerance: weight(primer_base, template_base)
+# WC = 1.0, G·T wobble / G·A stable = 0.95.
+# Weight prevents unnecessary wobble substitutions at positions with negligible
+# variation (<~5%), while still flipping positions with meaningful diversity.
+_WOBBLE_W = {
+    ('A', 'T'): 1.0, ('T', 'A'): 1.0, ('G', 'C'): 1.0, ('C', 'G'): 1.0,
+    ('G', 'T'): 0.80, ('T', 'G'): 0.80,
+    ('G', 'A'): 0.80, ('A', 'G'): 0.80,
+}
+_COMPLEMENT = {'A': 'T', 'T': 'A', 'G': 'C', 'C': 'G'}
+
+
+def _best_primer_base(template_freqs):
+    """Pick primer base with highest effective frequency against template."""
+    best_base, best_score = 'N', -1.0
+    for pb in 'ATGC':
+        score = sum(_WOBBLE_W.get((pb, tb), 0) * f for tb, f in template_freqs.items())
+        if score > best_score:
+            best_score = score
+            best_base = pb
+    return best_base, best_score
+
+
+def _column_sense_freqs(aligned_seqs, col):
+    """Get base frequency distribution at an MSA column (sense strand).
+
+    Only counts unambiguous bases (A, T, G, C). IUPAC codes and gaps are skipped.
+    """
+    from collections import Counter
+    bases = [s[col].upper() for s in aligned_seqs
+             if s[col].upper() in ('A', 'T', 'G', 'C')]
+    if not bases:
+        return {}
+    counts = Counter(bases)
+    total = len(bases)
+    return {b: c / total for b, c in counts.items()}
+
+
+def generate_primer_variants(aligned_seqs, start_col, primer_len, strand, n_variants=7,
+                              _freq_cache=None):
+    """Generate consensus + wobble-optimized primer variants at a position.
+
+    For fwd: primer bases = sense strand bases, template = antisense.
+    For rev: primer bases = complement of sense, template = sense.
+             Final sequence is reversed (RC construction).
+
+    Args:
+        _freq_cache: optional dict mapping col -> sense_freqs to avoid recomputing.
+
+    Returns list of primer sequences (5'->3'), up to n_variants.
+    """
+    consensus_bases = []
+    wobble_bases = []
+    gains = []
+
+    for i in range(primer_len):
+        col = start_col + i
+        if _freq_cache is not None and col in _freq_cache:
+            sense_freqs = _freq_cache[col]
+        else:
+            sense_freqs = _column_sense_freqs(aligned_seqs, col)
+        if not sense_freqs:
+            consensus_bases.append('N')
+            wobble_bases.append('N')
+            gains.append((i, 0.0))
+            continue
+
+        if strand == 'fwd':
+            cons_base = max(sense_freqs, key=sense_freqs.get)
+            template_freqs = {_COMPLEMENT[b]: f for b, f in sense_freqs.items()}
+        else:
+            sens_cons = max(sense_freqs, key=sense_freqs.get)
+            cons_base = _COMPLEMENT[sens_cons]
+            template_freqs = sense_freqs
+
+        consensus_bases.append(cons_base)
+
+        wob_base, wob_score = _best_primer_base(template_freqs)
+        wobble_bases.append(wob_base)
+
+        cons_score = sum(_WOBBLE_W.get((cons_base, tb), 0) * f
+                         for tb, f in template_freqs.items())
+        gains.append((i, wob_score - cons_score))
+
+    # Variable positions sorted by gain descending
+    variable = [(i, g) for i, g in gains if wobble_bases[i] != consensus_bases[i]]
+    variable.sort(key=lambda x: -x[1])
+
+    seen = set()
+    variants = []
+
+    def _add(bases):
+        key = tuple(bases)
+        if key not in seen:
+            seen.add(key)
+            variants.append(list(bases))
+
+    # 1. All consensus
+    _add(consensus_bases)
+    # 2. All wobble
+    _add(wobble_bases)
+    # 3. Single substitutions
+    for pos, _ in variable:
+        single = list(consensus_bases)
+        single[pos] = wobble_bases[pos]
+        _add(single)
+        if len(variants) >= n_variants:
+            break
+    # 4. Progressive accumulation (consensus → wobble one by one)
+    if len(variants) < n_variants:
+        cur = list(consensus_bases)
+        for pos, _ in variable:
+            cur = list(cur)
+            cur[pos] = wobble_bases[pos]
+            _add(cur)
+            if len(variants) >= n_variants:
+                break
+    # 5. Reverse progressive (wobble → consensus one by one)
+    if len(variants) < n_variants:
+        cur = list(wobble_bases)
+        for pos, _ in reversed(variable):
+            cur = list(cur)
+            cur[pos] = consensus_bases[pos]
+            _add(cur)
+            if len(variants) >= n_variants:
+                break
+
+    result = []
+    for v in variants[:n_variants]:
+        if 'N' in v:
+            continue
+        if strand == 'rev':
+            result.append(''.join(reversed(v)))
+        else:
+            result.append(''.join(v))
+    return result
+
+
+def score_amplicon_positions(aligned_seqs, primer_len, min_amp_len, max_amp_len,
+                             min_gc=0.35, max_gc=0.65,
+                             gap_threshold=0.50, min_primer_score=0.80,
+                             top_n=200, out_csv=None):
+    """Score amplicon positions across the full MSA using gap-aware conservation.
+
+    1. Columns with gap fraction > gap_threshold are skipped.
+    2. Per-column identity_frac = most_common_count / non_gap_count.
+    3. Consensus is built only from kept (non-gap-dominant) columns.
+    4. 20-mer positions are scored by mean conservation within contiguous
+       blocks of kept columns (no gap_score multiplication).
+    5. GC filter on consensus.
+
+    Returns:
+        positions: sorted list of (fwd_start_msa, rev_start_msa, score)
+        consensus_aligned: gap-aware consensus string (full MSA length,
+            '-' at skipped columns)
+        kept_cols: boolean array indicating which MSA columns are kept
+    """
+    seq_len = len(aligned_seqs[0])
+    n_seqs = len(aligned_seqs)
+
+    # Vectorize: convert to numpy array for fast column operations
+    _msa = np.array([list(s.upper()) for s in aligned_seqs], dtype='U1')
+
+    # Per-column base counts using vectorized operations
+    identity = np.zeros(seq_len, dtype=np.float64)
+    gap_frac = np.zeros(seq_len, dtype=np.float64)
+    consensus_bases = []
+
+    _is_gap = (_msa == '-') | (_msa == 'N')
+    _gap_counts = _is_gap.sum(axis=0)
+    gap_frac = _gap_counts / n_seqs
+
+    # Count each base per column
+    _base_A = (_msa == 'A').sum(axis=0)
+    _base_T = (_msa == 'T').sum(axis=0)
+    _base_G = (_msa == 'G').sum(axis=0)
+    _base_C = (_msa == 'C').sum(axis=0)
+    _n_bases = _base_A + _base_T + _base_G + _base_C
+
+    for col in range(seq_len):
+        if _n_bases[col] > 0 and gap_frac[col] <= gap_threshold:
+            counts = {'A': int(_base_A[col]), 'T': int(_base_T[col]),
+                       'G': int(_base_G[col]), 'C': int(_base_C[col])}
+            most_common_base = max(counts, key=counts.get)
+            consensus_bases.append(most_common_base)
+            sense_freqs = {b: c / n_seqs for b, c in counts.items() if c > 0}
+            anti_freqs = {_COMPLEMENT.get(b, b): f for b, f in sense_freqs.items()}
+            _, fwd_score = _best_primer_base(anti_freqs)
+            _, rev_score = _best_primer_base(sense_freqs)
+            identity[col] = max(fwd_score, rev_score)
+        else:
+            consensus_bases.append('-')
+            identity[col] = 0.0
+    del _msa, _is_gap, _gap_counts, _base_A, _base_T, _base_G, _base_C, _n_bases
+
+    # Boolean mask: kept columns (not gap-dominant)
+    kept_cols = np.array([b != '-' for b in consensus_bases], dtype=bool)
+    n_kept = kept_cols.sum()
+    n_skipped = seq_len - n_kept
+    print(f"  Gap-aware filtering: {n_kept} columns kept, {n_skipped} skipped "
+          f"(gap fraction > {gap_threshold})")
+
+    # Build consensus aligned string (full MSA length, '-' at skipped positions)
+    consensus_aligned = ''.join(consensus_bases)
+
+    # Identify contiguous blocks of kept columns for valid primer placement
+    # A valid 20-mer must sit entirely within a contiguous block of kept columns.
+    # Use cumsum of kept_cols to efficiently check: for a window [start, start+primer_len),
+    # all columns must be kept → sum of kept_cols in window == primer_len
+    max_start = seq_len - primer_len + 1
+    if max_start <= 0:
+        return [], consensus_aligned, kept_cols
+
+    cum_kept = np.concatenate([[0], np.cumsum(kept_cols.astype(np.int32))])
+    kept_in_window = cum_kept[primer_len:max_start + primer_len] - cum_kept[:max_start]
+    valid_pos = (kept_in_window == primer_len)  # True if all columns in window are kept
+
+    # Per-primer-position: mean conservation (only for valid positions)
+    cum_id = np.concatenate([[0.0], np.cumsum(identity)])
+    mean_cons = (cum_id[primer_len:max_start + primer_len] - cum_id[:max_start]) / primer_len
+
+    # Primer scores = mean conservation (no gap_score multiplication)
+    primer_scores = mean_cons.copy()
+    # Zero out invalid positions (those spanning gap-dominant columns)
+    primer_scores[~valid_pos] = 0.0
+
+    # Save per-position scores CSV
+    if out_csv:
+        import csv
+        half_w = primer_len // 2
+        with open(out_csv, 'w', newline='') as f:
+            w = csv.writer(f)
+            w.writerow(['msa_position', 'conservation', 'valid', 'primer_score'])
+            for pos in range(len(primer_scores)):
+                center = pos + half_w
+                w.writerow([center, f'{mean_cons[pos]:.6f}',
+                           '1' if valid_pos[pos] else '0',
+                           f'{primer_scores[pos]:.6f}'])
+        print(f"  Saved position scores: {out_csv} ({len(primer_scores)} positions, "
+              f"{valid_pos.sum()} valid)")
+
+    # GC content per primer position (from consensus, only for valid positions)
+    gc_arr = np.array([1.0 if b in 'GC' else 0.0 for b in consensus_bases])
+    cum_gc = np.concatenate([[0.0], np.cumsum(gc_arr)])
+    primer_gc = (cum_gc[primer_len:max_start + primer_len] - cum_gc[:max_start]) / primer_len
+
+    # For each fwd_start, find best rev within valid amplicon range
+    min_gap = 10
+    results = []
+    for fwd_start in range(len(primer_scores)):
+        if not valid_pos[fwd_start]:
+            continue
+        fwd_score = primer_scores[fwd_start]
+        if fwd_score < min_primer_score:
+            continue
+        fwd_gc = primer_gc[fwd_start]
+        if fwd_gc < min_gc or fwd_gc > max_gc:
+            continue
+
+        rev_lo = fwd_start + min_amp_len - primer_len
+        rev_hi = fwd_start + max_amp_len - primer_len + 1
+        rev_lo = max(0, rev_lo)
+        rev_hi = min(len(primer_scores), rev_hi)
+        if rev_lo >= rev_hi:
+            continue
+
+        # Filter rev positions: must be valid and pass score/GC
+        rev_valid_mask = valid_pos[rev_lo:rev_hi]
+        rev_score_mask = primer_scores[rev_lo:rev_hi] >= min_primer_score
+        rev_slice = primer_scores[rev_lo:rev_hi].copy()
+        rev_gc_slice = primer_gc[rev_lo:rev_hi]
+        gc_mask = ((rev_gc_slice >= min_gc) & (rev_gc_slice <= max_gc)
+                   & rev_valid_mask & rev_score_mask)
+        if not gc_mask.any():
+            continue
+        rev_slice[~gc_mask] = -1.0
+
+        best_rev_local = np.argmax(rev_slice)
+        best_rev_idx = rev_lo + best_rev_local
+        if rev_slice[best_rev_local] < 0:
+            continue
+
+        amp_score = fwd_score + primer_scores[best_rev_idx]
+        results.append((fwd_start, best_rev_idx, amp_score))
+
+    results.sort(key=lambda x: -x[2])
+
+    # Deduplicate: skip positions within min_gap of a higher-scoring one
+    filtered = []
+    used_fwd = []
+    for fwd_start, rev_start, score in results:
+        if any(abs(fwd_start - u) < min_gap for u in used_fwd):
+            continue
+        used_fwd.append(fwd_start)
+        filtered.append((fwd_start, rev_start, score))
+
+    return filtered[:top_n], consensus_aligned, kept_cols
+
+
+def extract_primers_at_positions(aligned_seqs, positions, primer_len,
+                                 min_tm, max_tm, max_gc, min_dg,
+                                 n_variants=N_VARIANTS, max_pri_len=None):
+    """Generate wobble-optimized primer variants at scored positions.
+
+    For each position, generates up to n_variants fwd and rev primers
+    at each length from primer_len to max_pri_len, mixing consensus
+    and wobble-tolerant bases.  Filters Tm/GC/dG.
+
+    Returns list of primer pair dicts and features dict.
+    """
+    if max_pri_len is None:
+        max_pri_len = primer_len
+    primer_lengths = list(range(primer_len, max_pri_len + 1))
+
+    primers = []
+    features = {}
+
+    fwd_candidates = []  # (pos_idx, var_idx, seq, tm, gc, pos_score)
+    rev_candidates = []
+
+    # Pre-compute column frequencies for all columns needed across all positions
+    seq_len = len(aligned_seqs[0])
+    needed_cols = set()
+    for fwd_start, rev_start, _ in positions:
+        for plen in primer_lengths:
+            for i in range(plen):
+                if fwd_start + i < seq_len:
+                    needed_cols.add(fwd_start + i)
+                if rev_start + i < seq_len:
+                    needed_cols.add(rev_start + i)
+    freq_cache = {}
+    for col in needed_cols:
+        freq_cache[col] = _column_sense_freqs(aligned_seqs, col)
+
+    for pos_idx, (fwd_start, rev_start, pos_score) in enumerate(positions):
+        for plen in primer_lengths:
+            if fwd_start + plen > seq_len or rev_start + plen > seq_len:
+                continue
+            fwd_vars = generate_primer_variants(aligned_seqs, fwd_start, plen, 'fwd', n_variants,
+                                                 _freq_cache=freq_cache)
+            for vi, fwd_seq in enumerate(fwd_vars):
+                if 'N' in fwd_seq:
+                    continue
+                tm = get_tm(fwd_seq)
+                gc = gc_fraction(fwd_seq)
+                if min_tm <= tm <= max_tm and gc <= max_gc / 100.0:
+                    fwd_candidates.append((pos_idx, vi, fwd_seq, tm, gc, pos_score))
+
+            rev_vars = generate_primer_variants(aligned_seqs, rev_start, plen, 'rev', n_variants,
+                                                 _freq_cache=freq_cache)
+            for vi, rev_seq in enumerate(rev_vars):
+                if 'N' in rev_seq:
+                    continue
+                tm = get_tm(rev_seq)
+                gc = gc_fraction(rev_seq)
+                if min_tm <= tm <= max_tm and gc <= max_gc / 100.0:
+                    rev_candidates.append((pos_idx, vi, rev_seq, tm, gc, pos_score))
+
+    # Batch self-dG
+    all_seqs = [c[2] for c in fwd_candidates] + [c[2] for c in rev_candidates]
+    if not all_seqs:
+        return [], {}
+
+    dg_values = compute_batch_dimer_dg([(s, s) for s in all_seqs])
+    fwd_dgs = dg_values[:len(fwd_candidates)]
+    rev_dgs = dg_values[len(fwd_candidates):]
+
+    fwd_passed = {}
+    for (pos_idx, vi, seq, tm, gc, pos_score), dg in zip(fwd_candidates, fwd_dgs):
+        if dg < min_dg:
+            continue
+        fwd_passed[(pos_idx, vi)] = {
+            'seq': seq, 'tm': tm, 'gc': gc, 'dg': dg, 'pos_score': pos_score,
+        }
+        features[seq] = {'len': len(seq), 'Tm': round(tm, 2), 'GC': round(gc, 4), 'dG': round(dg, 2)}
+
+    rev_passed = {}
+    for (pos_idx, vi, seq, tm, gc, pos_score), dg in zip(rev_candidates, rev_dgs):
+        if dg < min_dg:
+            continue
+        rev_passed[(pos_idx, vi)] = {
+            'seq': seq, 'tm': tm, 'gc': gc, 'dg': dg, 'pos_score': pos_score,
+        }
+        features[seq] = {'len': len(seq), 'Tm': round(tm, 2), 'GC': round(gc, 4), 'dG': round(dg, 2)}
+
+    # Build all fwd×rev pairs at each position
+    candidate_pairs = []
+    for pos_idx, (fwd_start, rev_start, pos_score) in enumerate(positions):
+        pos_fwd = [(vi, info) for (pi, vi), info in fwd_passed.items() if pi == pos_idx]
+        pos_rev = [(vi, info) for (pi, vi), info in rev_passed.items() if pi == pos_idx]
+        for fwd_vi, _ in pos_fwd:
+            for rev_vi, _ in pos_rev:
+                candidate_pairs.append((pos_idx, fwd_vi, rev_vi,
+                                        fwd_start, rev_start, pos_score))
+
+    # Batch cross-dimer dG
+    if candidate_pairs:
+        cross_seqs = [(fwd_passed[(p[0], p[1])]['seq'], rev_passed[(p[0], p[2])]['seq'])
+                      for p in candidate_pairs]
+        cross_dgs = compute_batch_dimer_dg(cross_seqs)
+    else:
+        cross_dgs = []
+
+    for (pos_idx, fwd_vi, rev_vi, fwd_start, rev_start, pos_score), cross_dg in zip(candidate_pairs, cross_dgs):
+        if cross_dg < min_dg:
+            continue
+        fwd_info = fwd_passed[(pos_idx, fwd_vi)]
+        rev_info = rev_passed[(pos_idx, rev_vi)]
+        primers.append({
+            'pos_idx': pos_idx,
+            'seq_idx': 0,
+            'seq_id': f"var_f{fwd_vi}_r{rev_vi}",
+            'is_consensus': (fwd_vi == 0 and rev_vi == 0),
+            'fwd_start_msa': fwd_start,
+            'rev_start_msa': rev_start,
+            'fwd_seq': fwd_info['seq'],
+            'rev_seq': rev_info['seq'],
+            'fwd_tm': fwd_info['tm'],
+            'rev_tm': rev_info['tm'],
+            'fwd_gc': fwd_info['gc'],
+            'rev_gc': rev_info['gc'],
+            'fwd_dg_self': fwd_info['dg'],
+            'rev_dg_self': rev_info['dg'],
+            'pair_dg_cross': cross_dg,
+            'score': pos_score,
+        })
+
+    return primers, features
+
+
+def group_into_batches(primers, primer_len, max_ref_span=500):
+    """Group primers by MSA position proximity, ensuring each batch's bowtie2
+    reference stays compact (within max_ref_span MSA columns).
+
+    Returns list of (batch_primers, min_fwd_start, max_rev_end) tuples.
+    """
+    if not primers:
+        return []
+
+    # Sort by fwd position
+    sorted_primers = sorted(primers, key=lambda p: p['fwd_start_msa'])
+
+    batches = []
+    current_batch = [sorted_primers[0]]
+    batch_min_fwd = sorted_primers[0]['fwd_start_msa']
+
+    for p in sorted_primers[1:]:
+        rev_end = p['rev_start_msa'] + primer_len
+        # Check if adding this primer would make the reference too wide
+        if rev_end - batch_min_fwd > max_ref_span:
+            # Finalize current batch
+            max_rev = max(pp['rev_start_msa'] + primer_len for pp in current_batch)
+            batches.append((current_batch, batch_min_fwd, max_rev))
+            current_batch = [p]
+            batch_min_fwd = p['fwd_start_msa']
+        else:
+            current_batch.append(p)
+
+    # Finalize last batch
+    if current_batch:
+        max_rev = max(pp['rev_start_msa'] + primer_len for pp in current_batch)
+        batches.append((current_batch, batch_min_fwd, max_rev))
+
+    return batches
+
+
+def extract_window_sequences(aligned_seqs, seq_ids, win_start, win_end):
+    """Extract window region from aligned sequences, strip gaps.
+
+    Returns list of (seq_id, ungapped_seq) tuples.
+    """
+    result = []
+    for seq_id, seq in zip(seq_ids, aligned_seqs):
+        window = seq[win_start:win_end]
+        ungapped = window.replace('-', '')
+        if len(ungapped) > 0:
+            result.append((seq_id, ungapped))
+    return result
+
+
+def _build_origin_map(target_seqs, for_filt, rev_filt,
+                      step, min_pri_len, max_pri_len, min_amp_len):
+    """Track which representative sequence each filtered primer originated from.
+
+    Returns origin_map: dict mapping primer_seq → set of origin indices.
+    The last index (len(target_seqs)-1) is the consensus sequence.
+    """
+    origin_map = {}  # primer_seq → set of origin indices
+    for idx, tseq in enumerate(target_seqs):
+        fwd, rev = generate_primers_single(tseq, step, min_pri_len, max_pri_len, min_amp_len)
+        for seq in fwd:
+            if seq in for_filt:
+                origin_map.setdefault(seq, set()).add(idx)
+        for seq in rev:
+            if seq in rev_filt:
+                origin_map.setdefault(seq, set()).add(idx)
+    return origin_map
+
+
+def _compute_position_bins(for_filt, n_bins):
+    """Create n_bins overlapping windows across forward primer positions.
+
+    Uses stride = range/n_bins and width = stride*2, so adjacent bins
+    overlap by ~50%. This prevents primer pairs near bin boundaries
+    from being missed.
+
+    Returns list of (bin_start, bin_end) tuples.
+    """
+    positions = sorted(for_filt.values())
+    if not positions:
+        return []
+    min_pos = positions[0]
+    max_pos = positions[-1]
+    total_range = max_pos - min_pos + 1
+    stride = max(1, total_range / n_bins)
+    width = stride * 2  # 50% overlap between adjacent bins
+    return [(min_pos + i * stride, min_pos + i * stride + width)
+            for i in range(n_bins)]
+
+
+def _select_batch_primers(for_filt, rev_filt, features, origin_map,
+                          n_origins, origin_weights, bin_start, bin_end,
+                          min_amp_len, max_amp_len,
+                          max_per_direction=PRIMERS_PER_BATCH):
+    """Select primers from a position bin with proportional origin allocation.
+
+    Each origin gets a quota proportional to its cluster_frac (weight).
+    For each origin, forward primers are selected first, then for each
+    forward primer at least one valid reverse primer is guaranteed.
+
+    Args:
+        origin_weights: dict mapping origin_idx → weight (cluster_frac).
+            Consensus (last origin) gets equal share with smallest medoid cluster.
+
+    Returns (fwd_list, rev_list) of primer sequences.
+    """
+    # Group fwd candidates by primary origin
+    fwd_by_origin = {i: [] for i in range(n_origins)}
+    for seq, pos in for_filt.items():
+        if not (bin_start <= pos < bin_end):
+            continue
+        origins = origin_map.get(seq, set())
+        if not origins:
+            continue
+        primary = min(origins)
+        fwd_by_origin[primary].append(seq)
+
+    # Group rev candidates by primary origin
+    rev_min = bin_start + min_amp_len
+    rev_max = bin_end + max_amp_len
+    rev_by_origin = {i: [] for i in range(n_origins)}
+    for seq, pos in rev_filt.items():
+        if not (rev_min <= pos <= rev_max):
+            continue
+        origins = origin_map.get(seq, set())
+        if not origins:
+            continue
+        primary = min(origins)
+        rev_by_origin[primary].append(seq)
+
+    # Sort each origin's candidates by rep_count descending
+    for origin_idx in range(n_origins):
+        fwd_by_origin[origin_idx].sort(
+            key=lambda s: -features.get(s, {}).get("rep_count", 1))
+        rev_by_origin[origin_idx].sort(
+            key=lambda s: -features.get(s, {}).get("rep_count", 1))
+
+    # Compute per-origin quota proportional to weights
+    active_origins = [i for i in range(n_origins)
+                      if fwd_by_origin[i] and rev_by_origin[i]]
+    if not active_origins:
+        # Fallback: try origins with at least fwd OR rev
+        all_fwd = [s for i in range(n_origins) for s in fwd_by_origin[i]]
+        all_rev = [s for i in range(n_origins) for s in rev_by_origin[i]]
+        all_fwd.sort(key=lambda s: -features.get(s, {}).get("rep_count", 1))
+        all_rev.sort(key=lambda s: -features.get(s, {}).get("rep_count", 1))
+        return all_fwd[:max_per_direction], all_rev[:max_per_direction]
+
+    total_weight = sum(origin_weights.get(i, 1.0) for i in active_origins)
+    quotas = {}
+    for i in active_origins:
+        w = origin_weights.get(i, 1.0)
+        quotas[i] = max(1, int(round(max_per_direction * w / total_weight)))
+
+    # Select fwd+rev pairs per origin
+    fwd_selected = []
+    rev_selected = []
+    rev_selected_set = set()
+
+    for origin_idx in active_origins:
+        quota = quotas[origin_idx]
+        fwd_cands = fwd_by_origin[origin_idx]
+        rev_cands = rev_by_origin[origin_idx]
+
+        n_fwd_take = min(quota, len(fwd_cands))
+        fwd_taken = fwd_cands[:n_fwd_take]
+        fwd_selected.extend(fwd_taken)
+
+        # For each fwd, ensure at least one valid rev exists in selection
+        # Take up to quota rev primers, prioritizing those that form valid
+        # amplicons with the selected fwd primers
+        n_rev_take = min(quota, len(rev_cands))
+        for rev_seq in rev_cands[:n_rev_take]:
+            if rev_seq not in rev_selected_set:
+                rev_selected.append(rev_seq)
+                rev_selected_set.add(rev_seq)
+
+    # Fill remaining slots from any origin
+    remaining_fwd = max_per_direction - len(fwd_selected)
+    remaining_rev = max_per_direction - len(rev_selected)
+
+    if remaining_fwd > 0 or remaining_rev > 0:
+        used_fwd = set(fwd_selected)
+        used_rev = rev_selected_set
+        leftover_fwd = []
+        leftover_rev = []
+        for i in range(n_origins):
+            leftover_fwd.extend(s for s in fwd_by_origin[i] if s not in used_fwd)
+            leftover_rev.extend(s for s in rev_by_origin[i] if s not in used_rev)
+        leftover_fwd.sort(key=lambda s: -features.get(s, {}).get("rep_count", 1))
+        leftover_rev.sort(key=lambda s: -features.get(s, {}).get("rep_count", 1))
+        fwd_selected.extend(leftover_fwd[:remaining_fwd])
+        rev_selected.extend(leftover_rev[:remaining_rev])
+
+    return fwd_selected, rev_selected
+
+
+def _write_batch_fasta_and_features(fwd_seqs, rev_seqs, features, name, batch_idx, tmpdir):
+    """Write FASTA and features CSV for a batch of primers.
+
+    Deduplicates sequences so each unique seq gets one FASTA entry and one
+    name for bowtie2.  Returns (fasta_path, features_path, fwd_name_to_seq,
+    rev_name_to_seq) where the dicts map assigned_name -> seq for every input
+    entry (including duplicates).
+    """
+    fasta_path = Path(tmpdir) / f"batch_{batch_idx}.fa"
+    feat_path = Path(tmpdir) / f"batch_{batch_idx}.feat"
+
+    fwd_name_to_seq = {}  # pname -> seq  (all entries)
+    rev_name_to_seq = {}
+    fwd_seen = {}  # seq -> canonical pname (first seen)
+    rev_seen = {}
+    feat_rows = []
+
+    with open(fasta_path, "w") as f:
+        for i, seq in enumerate(fwd_seqs):
+            pname = f"{name}_q{batch_idx}_{i+1}_f"
+            fwd_name_to_seq[pname] = seq
+            if seq not in fwd_seen:
+                fwd_seen[seq] = pname
+                f.write(f">{pname}\n{seq}\n")
+                feat = features.get(seq, {})
+                feat_rows.append({
+                    "pname": pname, "pseq": seq, "forrev": "f",
+                    "len": feat.get("len", len(seq)),
+                    "Tm": feat.get("Tm", 0), "GC": feat.get("GC", 0),
+                    "dG": feat.get("dG", 0),
+                })
+
+        for i, seq in enumerate(rev_seqs):
+            pname = f"{name}_q{batch_idx}_{i+1}_r"
+            rev_name_to_seq[pname] = seq
+            if seq not in rev_seen:
+                rev_seen[seq] = pname
+                f.write(f">{pname}\n{seq}\n")
+                feat = features.get(seq, {})
+                feat_rows.append({
+                    "pname": pname, "pseq": seq, "forrev": "r",
+                    "len": feat.get("len", len(seq)),
+                    "Tm": feat.get("Tm", 0), "GC": feat.get("GC", 0),
+                    "dG": feat.get("dG", 0),
+                })
+
+    pd.DataFrame(feat_rows).to_csv(feat_path, index=False)
+    return fasta_path, feat_path, fwd_name_to_seq, rev_name_to_seq
+
+
+def _align_batch(fasta_path, index_prefix, n_targets, threads, tmpdir, batch_idx):
+    """Align batch primers with bowtie2 and parse SAM into mapped format.
+
+    Returns path to mapped file.
+    """
+    sam_path = Path(tmpdir) / f"batch_{batch_idx}.sam"
+    mapped_path = Path(tmpdir) / f"batch_{batch_idx}.mapped"
+
+    k = min(n_targets * 2, 50000)
+    cmd = [
+        "bowtie2",
+        "-x", str(index_prefix),
+        "-U", str(fasta_path),
+        "-f",
+        "-p", str(threads),
+        "-k", str(k),
+        "--mp", "2,2", "--np", "2",
+        "--rdg", "4,4", "--rfg", "4,4",
+        "-L", "6", "-N", "1",
+        "--score-min", "L,-0.6,-0.6",
+        "--no-hd", "--no-unal",
+        "-S", str(sam_path),
+    ]
+    subprocess.run(cmd, check=True, capture_output=True)
+
+    if not sam_path.exists() or sam_path.stat().st_size == 0:
+        mapped_path.touch()
+        return mapped_path
+
+    # Parse SAM with sam2pairwise
+    parsed_path = Path(tmpdir) / f"batch_{batch_idx}.parsed"
+    with open(sam_path) as fin, open(parsed_path, "w") as fout:
+        result = subprocess.run(
+            ["sam2pairwise"], input=fin.read(), capture_output=True, text=True
+        )
+        fout.write(result.stdout)
+
+    if parsed_path.stat().st_size == 0:
+        mapped_path.touch()
+        return mapped_path
+
+    # Parse the sam2pairwise output and combine with SAM columns
+    # sam2pairwise outputs 4-line groups: header, pseq, match, tseq
+    sam_lines = []
+    with open(sam_path) as f:
+        for line in f:
+            parts = line.rstrip("\n").split("\t")
+            # columns: pname, flag, tname, pos
+            sam_lines.append((parts[0], parts[1], parts[2], parts[3]))
+
+    parsed_lines = []
+    with open(parsed_path) as f:
+        lines = f.read().splitlines()
+
+    # Group into 4-line blocks
+    n_blocks = len(lines) // 4
+    with open(mapped_path, "w") as out:
+        for i in range(n_blocks):
+            # pseq = line 1 (0-indexed: 4*i + 1), match = line 2, tseq = line 3
+            pseq = lines[4 * i + 1]
+            match = lines[4 * i + 2]
+            tseq = lines[4 * i + 3]
+            if i < len(sam_lines):
+                pname, flag, tname, pos = sam_lines[i]
+                out.write(f"{pname}\t{flag}\t{tname}\t{pos}\t{pseq}\t{tseq}\t{match}\n")
+
+    return mapped_path
+
+
+def _apply_coverage_filter(mapped_path, n_targets, tmpdir, batch_idx, cov_frac=0.95):
+    """Filter primers covering less than cov_frac of target sequences. Returns filtered mapped path."""
+    filtered_path = Path(tmpdir) / f"batch_{batch_idx}.mapped.filt"
+    min_cov = int(n_targets * cov_frac)
+
+    if mapped_path.stat().st_size == 0:
+        filtered_path.touch()
+        return filtered_path
+
+    df = pd.read_csv(mapped_path, sep="\t", header=None,
+                     names=["pname", "flag", "tname", "pos", "pseq", "tseq", "match"])
+
+    # Count unique targets per primer
+    cov = df.groupby("pname")["tname"].nunique()
+    good_primers = set(cov[cov >= min_cov].index)
+
+    if not good_primers:
+        filtered_path.touch()
+        return filtered_path
+
+    df[df["pname"].isin(good_primers)].to_csv(
+        filtered_path, sep="\t", header=False, index=False
+    )
+    return filtered_path
+
+
+def _run_evaluate(input_path, ref_path, scaler, classifier, regressor, device, threads,
+                   n_targets_global=None):
+    """Run ML evaluation on prepared input. Returns DataFrame with scored pairs.
+
+    Args:
+        n_targets_global: if provided, use this as denominator for coverage
+            instead of the batch-local target count.
+
+    Returns:
+        (res, eval_re, eval_full, eval_cl): res is the scored summary, eval_re is per-target
+        activity, eval_full is the raw per-row ML output (for .eval.full file),
+        eval_cl is the classifier per-target table (for .eval.cl file).
+    """
+    if not input_path.exists() or input_path.stat().st_size == 0:
+        return pd.DataFrame(), pd.DataFrame(), pd.DataFrame()
+
+    tnames = [s.id for s in SeqIO.parse(ref_path, "fasta")]
+    n_for_coverage = n_targets_global if n_targets_global is not None else len(tnames)
+
+    clstbl_list, regtbl_list = [], []
+    full_chunks = []
+
+    for chunk in pd.read_csv(input_path, chunksize=20000):
+        if chunk.empty:
+            continue
+        chunk["targets"] = chunk["targets"].apply(ast.literal_eval)
+
+        inps_fe = chunk[FEATURE_COLUMNS]
+        inps_fe = scaler.transform(inps_fe)
+        inps_se = chunk[["pseq_f", "tseq_f", "pseq_r", "tseq_r"]]
+        inps_se = encode_batch_parallel(inps_se, threads)
+        dataset = PcrDataset(inps_se, inps_fe, np.array([0] * len(chunk)))
+        loader = DataLoader(dataset, batch_size=256, shuffle=False)
+
+        predict_cls, predict_reg = [], []
+        with torch.no_grad():
+            for seq_in, fea_in, _ in loader:
+                seq_in = seq_in.to(device).float()
+                fea_in = fea_in.to(device).float()
+                out_cls = classifier(fea_in, seq_in)
+                out_reg = regressor(fea_in, seq_in)
+                if len(seq_in) == 1:
+                    predict_cls.append(np.array([out_cls.squeeze().detach().cpu().numpy()]))
+                    predict_reg.append(np.array([out_reg.squeeze().detach().cpu().numpy()]))
+                else:
+                    predict_cls.append(out_cls.squeeze().detach().cpu().numpy())
+                    predict_reg.append(out_reg.squeeze().detach().cpu().numpy())
+
+        predict_cls = np.concatenate(predict_cls)
+        predict_reg = np.round(np.concatenate(predict_reg), decimals=3)
+
+        chunk.loc[:, "classifier"] = predict_cls
+        chunk.loc[:, "regressor"] = predict_reg
+        full_chunks.append(chunk.copy())
+
+        mlb = MultiLabelBinarizer()
+        onehot = mlb.fit_transform(chunk["targets"])
+        target_cols = list(mlb.classes_)
+
+        for label, lst in zip(["classifier", "regressor"], [clstbl_list, regtbl_list]):
+            targets_df = pd.DataFrame(onehot, columns=target_cols, index=chunk.index)
+            targets_df = targets_df.mul(chunk[label], axis=0)
+            evaltbl = pd.concat([chunk[["pname_f", "pname_r"]], targets_df], axis=1)
+            agg_dict = {c: "max" for c in evaltbl.columns[2:]}
+            evaltbl = evaltbl.groupby(["pname_f", "pname_r"]).agg(agg_dict).reset_index()
+            lst.append(evaltbl)
+
+    if not clstbl_list:
+        return pd.DataFrame(), pd.DataFrame(), pd.DataFrame(), pd.DataFrame()
+
+    eval_full = pd.concat(full_chunks, ignore_index=True) if full_chunks else pd.DataFrame()
+
+    clstbl = pd.concat(clstbl_list, ignore_index=True)
+    regtbl = pd.concat(regtbl_list, ignore_index=True).reindex(columns=clstbl.columns)
+    agg_dict = {c: "max" for c in regtbl.columns[2:]}
+    regtbl = regtbl.reset_index().groupby(["pname_f", "pname_r"]).agg(agg_dict)
+    clstbl = clstbl.reset_index().groupby(["pname_f", "pname_r"]).agg(agg_dict)
+
+    coverage = (clstbl > 0.5).sum(axis=1).reset_index(name="coverage")
+    coverage["coverage"] = coverage["coverage"] / n_for_coverage
+
+    active_mask = clstbl > 0.5
+    active_reg = regtbl.where(active_mask)
+    activity = active_reg.sum(axis=1).reset_index(name="activity")
+    activity["activity"] = activity["activity"] / n_for_coverage
+
+    res = coverage.merge(activity, on=["pname_f", "pname_r"])
+    res["activity"] = res["activity"].fillna(0)
+    res["score"] = res["coverage"] * res["activity"]
+    res = res.sort_values("activity", ascending=False)
+
+    # Build per-target classifier table (for .eval.cl file)
+    eval_cl = clstbl.fillna(0).round(3).reset_index()
+
+    # Build per-target activity table (active_reg with 0 for inactive)
+    eval_re = active_reg.fillna(0).reset_index()
+    eval_re = eval_re.round(4)
+
+    return res.round(4), eval_re, eval_full, eval_cl
+
+
+def run(args):
+    """Run quick-design command."""
+    start_time = time.time()
+    params = parse_params(args.param_file)
+    primer_params = get_primer_params(params)
+
+    min_amp_len = primer_params["min_amp_len"]
+    max_amp_len = primer_params["max_amp_len"]
+    min_dg = primer_params["min_dg"]
+
+    cov_min = float(params.get("QUICK_COV_MIN", 1.0))
+    act_min = float(params.get("QUICK_ACT_MIN", 1.0))
+    min_pairs = int(params.get("QUICK_MIN_PAIRS", 5))
+
+    # Route based on mode
+    if args.msa and getattr(args, 'probe_mode', False):
+        return _run_probe_first(args, params, primer_params, cov_min, act_min, min_pairs, start_time)
+    elif args.msa:
+        return _run_multi_region(args, params, primer_params, cov_min, act_min, min_pairs, start_time)
+    else:
+        return _run_single_window(args, params, primer_params, cov_min, act_min, min_pairs, start_time)
+
+
+############################################
+# Probe-first quick design
+############################################
+
+
+def _find_probe_regions_msa(aligned_seqs, probe_params, gap_threshold=0.50,
+                            fallback_top_n=5, fallback_min_coverage=0.70):
+    """Scan gap-filtered MSA for conserved probe regions.
+
+    Uses conventional conservation (most-common-base fraction) to identify
+    regions where variable columns <= max_mismatches within a probe_len_max
+    window.
+
+    If no strictly conserved regions are found, falls back to a per-sequence
+    scoring approach: for each window, counts how many sequences match the
+    consensus with <= max_mismatches, and returns the top windows by coverage.
+
+    Returns:
+        List of (msa_start, msa_end, n_variable) tuples in MSA coordinates.
+        For fallback regions, n_variable is set to max_mismatches.
+    """
+
+    seq_len = len(aligned_seqs[0])
+    n_seqs = len(aligned_seqs)
+    probe_len_max = probe_params["len_max"]
+    max_var = probe_params["max_mismatches"]
+    cons_thresh = probe_params["conservation_threshold"]
+
+    # Per-column: compute conservation and identify valid (non-gap-dominant) columns
+    is_variable = np.zeros(seq_len, dtype=bool)
+    is_valid = np.zeros(seq_len, dtype=bool)
+
+    _msa = np.array([list(s.upper()) for s in aligned_seqs], dtype='U1')
+    _is_gap = (_msa == '-') | (_msa == 'N')
+    _gap_counts = _is_gap.sum(axis=0)
+
+    _base_A = (_msa == 'A').sum(axis=0)
+    _base_T = (_msa == 'T').sum(axis=0)
+    _base_G = (_msa == 'G').sum(axis=0)
+    _base_C = (_msa == 'C').sum(axis=0)
+    _n_bases = _base_A + _base_T + _base_G + _base_C
+
+    # Consensus base per column (for fallback scoring)
+    consensus_arr = np.full(seq_len, 'N', dtype='U1')
+    for col in range(seq_len):
+        gap_frac = _gap_counts[col] / n_seqs
+        if gap_frac > gap_threshold or _n_bases[col] == 0:
+            continue
+        is_valid[col] = True
+        counts = [int(_base_A[col]), int(_base_T[col]),
+                  int(_base_G[col]), int(_base_C[col])]
+        most_common = max(counts)
+        bases = ['A', 'T', 'G', 'C']
+        consensus_arr[col] = bases[counts.index(most_common)]
+        conservation = most_common / int(_n_bases[col])
+        if conservation < cons_thresh:
+            is_variable[col] = True
+
+    if seq_len < probe_len_max:
+        del _msa, _is_gap, _gap_counts, _base_A, _base_T, _base_G, _base_C, _n_bases
+        return []
+
+    cum_valid = np.concatenate([[0], np.cumsum(is_valid.astype(np.int32))])
+    cum_var = np.concatenate([[0], np.cumsum(is_variable.astype(np.int32))])
+
+    # --- Strict pass: all columns valid, variable count <= max_var ---
+    conserved_starts = []
+    for start in range(seq_len - probe_len_max + 1):
+        end = start + probe_len_max
+        n_valid = cum_valid[end] - cum_valid[start]
+        if n_valid < probe_len_max:
+            continue
+        n_var = cum_var[end] - cum_var[start]
+        if n_var <= max_var:
+            conserved_starts.append(start)
+
+    if conserved_starts:
+        del _msa, _is_gap, _gap_counts, _base_A, _base_T, _base_G, _base_C, _n_bases
+        return _merge_windows(conserved_starts, probe_len_max, cum_var)
+
+    # --- Fallback: score each valid window by per-sequence coverage ---
+    print("  No strictly conserved probe regions found. "
+          "Searching for best-available regions...")
+
+    # Find all valid windows (no gap-dominant columns)
+    valid_starts = []
+    for start in range(seq_len - probe_len_max + 1):
+        end = start + probe_len_max
+        n_valid = cum_valid[end] - cum_valid[start]
+        if n_valid < probe_len_max:
+            continue
+        valid_starts.append(start)
+
+    if not valid_starts:
+        del _msa, _is_gap, _gap_counts, _base_A, _base_T, _base_G, _base_C, _n_bases
+        return []
+
+    # For each valid window, count sequences matching consensus with <= max_var mismatches
+    # Build per-column mismatch matrix: 1 where seq differs from consensus
+    mismatch = (_msa != consensus_arr[np.newaxis, :]).astype(np.int32)
+    # Gaps don't count as mismatches (they're filtered by valid columns)
+    mismatch[_is_gap] = 0
+    cum_mm = np.concatenate([np.zeros((n_seqs, 1), dtype=np.int32),
+                             np.cumsum(mismatch, axis=1)], axis=1)
+
+    del _msa, _is_gap, _gap_counts, _base_A, _base_T, _base_G, _base_C, _n_bases, mismatch
+
+    scored = []
+    for start in valid_starts:
+        end = start + probe_len_max
+        # Per-sequence mismatch count in this window
+        mm_counts = cum_mm[:, end] - cum_mm[:, start]
+        n_matching = int(np.sum(mm_counts <= max_var))
+        coverage = n_matching / n_seqs
+        if coverage >= fallback_min_coverage:
+            scored.append((start, coverage))
+
+    if not scored:
+        return []
+
+    # Sort by coverage descending, pick top N non-overlapping windows
+    scored.sort(key=lambda x: -x[1])
+    selected = []
+    for start, cov in scored:
+        end = start + probe_len_max
+        # Check no overlap with already selected
+        if any(not (end <= s or start >= e) for s, e, _, _ in selected):
+            continue
+        selected.append((start, end, max_var, cov))
+        if len(selected) >= fallback_top_n:
+            break
+
+    if not selected:
+        return []
+
+    # Sort by position
+    selected.sort()
+    regions = [(s, e, nv) for s, e, nv, _ in selected]
+
+    for s, e, nv, cov in selected:
+        print(f"    Fallback region: MSA cols {s}-{e} "
+              f"({e-s} bp, covers {cov:.1%} of sequences with ≤{max_var} mismatches)")
+
+    return regions
+
+
+def _merge_windows(conserved_starts, probe_len_max, cum_var):
+    """Merge overlapping conserved windows into contiguous regions."""
+    regions = []
+    reg_start = conserved_starts[0]
+    reg_end = conserved_starts[0] + probe_len_max
+
+    for s in conserved_starts[1:]:
+        if s <= reg_end:
+            reg_end = s + probe_len_max
+        else:
+            n_var = int(cum_var[reg_end] - cum_var[reg_start])
+            regions.append((reg_start, reg_end, n_var))
+            reg_start = s
+            reg_end = s + probe_len_max
+
+    n_var = int(cum_var[reg_end] - cum_var[reg_start])
+    regions.append((reg_start, reg_end, n_var))
+
+    return regions
+
+
+def _score_probes_by_coverage(probes, aligned_seqs, max_mismatches):
+    """Score each probe by fraction of sequences matching with <= max_mismatches.
+
+    For each probe, checks how many sequences in the MSA match the probe
+    consensus with at most max_mismatches substitutions in the probe window.
+
+    Adds 'coverage' field to each probe dict.
+    """
+    n_seqs = len(aligned_seqs)
+    _msa = np.array([list(s.upper()) for s in aligned_seqs], dtype='U1')
+
+    for probe in probes:
+        start = probe['msa_start']
+        end = probe['msa_end']
+        probe_seq = probe['seq']
+        # For rev strand probes, the consensus window is sense-strand
+        # The probe seq is RC of consensus, so compare against sense consensus
+        if probe['strand'] == 'rev':
+            sense_seq = reverse_complement_dna(probe_seq)
+        else:
+            sense_seq = probe_seq
+
+        # Count mismatches per sequence in this window
+        window = _msa[:, start:end]
+        probe_arr = np.array(list(sense_seq), dtype='U1')
+        mm_per_seq = np.sum(window != probe_arr[np.newaxis, :], axis=1)
+        # Don't count gaps as mismatches
+        gap_mask = (window == '-') | (window == 'N')
+        gap_per_seq = np.sum(gap_mask, axis=1)
+        mm_per_seq = mm_per_seq - gap_per_seq  # adjust for gaps
+        mm_per_seq = np.maximum(mm_per_seq, 0)
+
+        n_matching = int(np.sum(mm_per_seq <= max_mismatches))
+        probe['coverage'] = n_matching / n_seqs
+
+    del _msa
+
+
+def _select_top_probes(probes, top_n=5, min_distance=30):
+    """Select top N probes at distinct positions, ranked by coverage.
+
+    Ensures selected probes are at least min_distance apart in MSA coordinates.
+    """
+    # Sort by coverage descending, then by Tm closer to midpoint as tiebreaker
+    sorted_probes = sorted(probes, key=lambda p: (-p['coverage'], -p['tm']))
+
+    selected = []
+    for probe in sorted_probes:
+        mid = (probe['msa_start'] + probe['msa_end']) / 2
+        if any(abs(mid - (s['msa_start'] + s['msa_end']) / 2) < min_distance
+               for s in selected):
+            continue
+        selected.append(probe)
+        if len(selected) >= top_n:
+            break
+
+    return selected
+
+
+def _write_probe_mapping_csv(probes, aligned_seqs, seq_ids, out_path,
+                              max_mismatches):
+    """Write probe mapping CSV directly from MSA data, replacing bowtie2 alignment.
+
+    For each selected probe, computes per-sequence mismatches from the MSA
+    and writes rows in the same format as parse_probe_mapping.
+    Columns: probe_name, probe_seq, target_id, start_pos, orientation, mismatches, indels
+    """
+    _msa = np.array([list(s.upper()) for s in aligned_seqs], dtype='U1')
+
+    mappings = []
+    for probe in probes:
+        start = probe['msa_start']
+        end = probe['msa_end']
+        probe_seq = probe['seq']
+        strand = probe.get('strand', 'fwd')
+        orientation = '+' if strand == 'fwd' else '-'
+
+        if strand == 'rev':
+            sense_seq = reverse_complement_dna(probe_seq)
+        else:
+            sense_seq = probe_seq
+
+        window = _msa[:, start:end]
+        probe_arr = np.array(list(sense_seq), dtype='U1')
+
+        for i, seq_id in enumerate(seq_ids):
+            seq_window = window[i]
+            # Count gaps and mismatches
+            gap_mask = (seq_window == '-') | (seq_window == 'N')
+            n_gaps = int(gap_mask.sum())
+            mm = int(np.sum(seq_window != probe_arr)) - n_gaps
+            mm = max(mm, 0)
+
+            if mm > max_mismatches:
+                continue
+
+            # Compute ungapped position for this sequence
+            seq_chars = np.array(list(aligned_seqs[i].upper()), dtype='U1')
+            non_gap = (seq_chars != '-')
+            ungapped_pos = int(non_gap[:start].sum())
+
+            mappings.append({
+                'probe_name': probe['name'],
+                'probe_seq': probe_seq,
+                'target_id': seq_id,
+                'start_pos': ungapped_pos,
+                'orientation': orientation,
+                'mismatches': mm,
+                'indels': 0,
+            })
+
+    df = pd.DataFrame(mappings)
+    Path(out_path).parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(out_path, index=False)
+    print(f"  Saved probe mapping: {out_path} ({len(df)} mappings)")
+
+
+def _generate_probes_from_msa(aligned_seqs, regions, probe_params):
+    """Generate probe candidates from conserved MSA regions.
+
+    Builds consensus at each region, tiles probes of len_min to len_max on
+    both strands, filters by Tm/GC/homopolymer/5'G/self-dimer.
+
+    Returns:
+        probes: list of dicts {name, seq, region_idx, msa_start, msa_end, tm, gc, dg, strand}
+        probe_features: dict mapping probe_name -> {pseq, len, Tm, GC, dG}
+    """
+    from collections import Counter
+
+    len_min = probe_params["len_min"]
+    len_max = probe_params["len_max"]
+    min_tm = probe_params["min_tm"]
+    max_tm = probe_params["max_tm"]
+    max_gc = probe_params["max_gc"] / 100.0
+    homopolymer_max = probe_params["homopolymer_max"]
+    avoid_5g = probe_params["avoid_5prime_g"]
+    min_dg = probe_params["min_dg"]
+
+    # Build consensus across full MSA
+    n_seqs = len(aligned_seqs)
+    seq_len = len(aligned_seqs[0])
+    _msa = np.array([list(s.upper()) for s in aligned_seqs], dtype='U1')
+    _base_A = (_msa == 'A').sum(axis=0)
+    _base_T = (_msa == 'T').sum(axis=0)
+    _base_G = (_msa == 'G').sum(axis=0)
+    _base_C = (_msa == 'C').sum(axis=0)
+
+    consensus = []
+    for col in range(seq_len):
+        counts = {'A': int(_base_A[col]), 'T': int(_base_T[col]),
+                  'G': int(_base_G[col]), 'C': int(_base_C[col])}
+        best = max(counts, key=counts.get)
+        consensus.append(best if counts[best] > 0 else 'N')
+    consensus_str = ''.join(consensus)
+    del _msa, _base_A, _base_T, _base_G, _base_C
+
+    candidates = []
+    for reg_idx, (reg_start, reg_end, _) in enumerate(regions):
+        region_seq = consensus_str[reg_start:reg_end]
+
+        for probe_len in range(len_min, len_max + 1):
+            for offset in range(len(region_seq) - probe_len + 1):
+                for strand in ('fwd', 'rev'):
+                    seq = region_seq[offset:offset + probe_len]
+                    if 'N' in seq:
+                        continue
+                    if strand == 'rev':
+                        seq = reverse_complement_dna(seq)
+
+                    # Fast filters
+                    if avoid_5g and seq[0] == 'G':
+                        continue
+                    if has_homopolymer(seq, homopolymer_max):
+                        continue
+                    tm = get_tm(seq)
+                    if tm < min_tm or tm > max_tm:
+                        continue
+                    gc = gc_fraction(seq)
+                    if gc > max_gc:
+                        continue
+
+                    msa_start = reg_start + offset
+                    msa_end = msa_start + probe_len
+                    candidates.append({
+                        'seq': seq,
+                        'region_idx': reg_idx,
+                        'msa_start': msa_start,
+                        'msa_end': msa_end,
+                        'tm': round(tm, 2),
+                        'gc': round(gc * 100, 1),
+                        'strand': strand,
+                    })
+
+    if not candidates:
+        return [], {}
+
+    # Batch self-dimer dG check
+    dimer_pairs = [(c['seq'], c['seq']) for c in candidates]
+    dg_values = compute_batch_dimer_dg(dimer_pairs)
+
+    probes = []
+    probe_features = {}
+    seen_seqs = set()
+    for i, cand in enumerate(candidates):
+        dg = dg_values[i] if dg_values[i] is not None else 0.0
+        if dg < min_dg:
+            continue
+        cand['dg'] = round(dg, 2)
+        # Deduplicate by sequence
+        if cand['seq'] in seen_seqs:
+            continue
+        seen_seqs.add(cand['seq'])
+        name = f"probe_r{cand['region_idx']}_{len(probes)+1}"
+        cand['name'] = name
+        probes.append(cand)
+        probe_features[name] = {
+            'pseq': cand['seq'],
+            'len': len(cand['seq']),
+            'Tm': cand['tm'],
+            'GC': cand['gc'],
+            'dG': cand['dg'],
+        }
+
+    return probes, probe_features
+
+
+def _find_flanking_primer_positions(selected_probes, identity, kept_cols,
+                                     primer_len, min_amp_len, max_amp_len,
+                                     buffer, min_primer_score=0.80,
+                                     min_gc=0.30, max_gc=0.65,
+                                     top_per_probe=50):
+    """Find valid primer positions flanking each selected probe.
+
+    For each individual probe (~25bp), searches for fwd positions upstream
+    and rev positions downstream, constrained by amplicon length and buffer.
+    Scores by wobble-aware primer conservation.
+
+    Args:
+        selected_probes: list of probe dicts with 'msa_start', 'msa_end', 'name'
+
+    Returns:
+        List of (fwd_start, rev_start, score, probe_idx) tuples,
+        where probe_idx indexes into selected_probes.
+    """
+    seq_len = len(identity)
+
+    # Pre-compute valid primer positions (contiguous kept columns of primer_len)
+    cum_kept = np.concatenate([[0], np.cumsum(kept_cols.astype(np.int32))])
+    max_start = seq_len - primer_len + 1
+    if max_start <= 0:
+        return []
+    kept_in_window = cum_kept[primer_len:max_start + primer_len] - cum_kept[:max_start]
+    valid_pos = (kept_in_window == primer_len)
+
+    # Mean conservation per primer position
+    cum_id = np.concatenate([[0.0], np.cumsum(identity)])
+    primer_scores = np.zeros(max_start)
+    primer_scores[:] = (cum_id[primer_len:max_start + primer_len] - cum_id[:max_start]) / primer_len
+    primer_scores[~valid_pos] = 0.0
+
+    all_positions = []
+    for probe_idx, probe in enumerate(selected_probes):
+        probe_start = probe['msa_start']
+        probe_end = probe['msa_end']
+
+        # Fwd zone: fwd_start + primer_len + buffer <= probe_start
+        fwd_max = probe_start - primer_len - buffer
+        # Rev zone: rev_start >= probe_end + buffer
+        rev_min = probe_end + buffer
+
+        if fwd_max < 0 or rev_min >= max_start:
+            continue
+
+        # Collect valid fwd positions
+        fwd_candidates = []
+        for fwd in range(max(0, fwd_max - max_amp_len), fwd_max + 1):
+            if fwd < 0 or fwd >= max_start:
+                continue
+            if primer_scores[fwd] < min_primer_score:
+                continue
+            fwd_candidates.append((fwd, primer_scores[fwd]))
+
+        if not fwd_candidates:
+            continue
+
+        # Sort by score, take top
+        fwd_candidates.sort(key=lambda x: -x[1])
+        fwd_candidates = fwd_candidates[:top_per_probe]
+
+        for fwd, fwd_score in fwd_candidates:
+            # Valid rev range for this fwd
+            amp_rev_lo = max(rev_min, fwd + min_amp_len - primer_len)
+            amp_rev_hi = min(max_start, fwd + max_amp_len - primer_len + 1)
+            if amp_rev_lo >= amp_rev_hi:
+                continue
+
+            # Find top rev positions in range (not just the best)
+            rev_slice = primer_scores[amp_rev_lo:amp_rev_hi].copy()
+            rev_valid = valid_pos[amp_rev_lo:amp_rev_hi]
+            rev_score_mask = rev_slice >= min_primer_score
+            combined = rev_valid & rev_score_mask
+            if not combined.any():
+                continue
+            rev_slice[~combined] = -1.0
+            # Take top 3 rev positions per fwd
+            top_rev_idxs = np.argsort(rev_slice)[::-1][:3]
+            for ri in top_rev_idxs:
+                if rev_slice[ri] < 0:
+                    break
+                rev = amp_rev_lo + int(ri)
+                combined_score = fwd_score + primer_scores[rev]
+                all_positions.append((fwd, rev, combined_score, probe_idx))
+
+    # Sort by score descending
+    all_positions.sort(key=lambda x: -x[2])
+    return all_positions
+
+
+def _check_probe_primer_dimers(results_df, probes, name_to_seq, min_dg=-6.0):
+    """Check probe-primer cross-dimer dG for passing pairs.
+
+    For each primer pair in results, checks dG of each probe against
+    both fwd and rev primers. Keeps only probes where both dG > min_dg.
+
+    Returns:
+        dict mapping (pname_f, pname_r) -> [compatible probe dicts]
+    """
+    if results_df.empty or not probes:
+        return {}
+
+    # Build all dimer check pairs
+    check_list = []  # (pair_key, probe, 'fwd'/'rev')
+    for _, row in results_df.iterrows():
+        pf, pr = row['pname_f'], row['pname_r']
+        fwd_seq = name_to_seq.get(pf)
+        rev_seq = name_to_seq.get(pr)
+        if not fwd_seq or not rev_seq:
+            continue
+        for probe in probes:
+            check_list.append(((pf, pr), probe, fwd_seq, rev_seq))
+
+    if not check_list:
+        return {}
+
+    # Build pairs for batch dG: (probe_seq, fwd_seq), (probe_seq, rev_seq)
+    dimer_pairs = []
+    for pair_key, probe, fwd_seq, rev_seq in check_list:
+        dimer_pairs.append((probe['seq'], fwd_seq))
+        dimer_pairs.append((probe['seq'], rev_seq))
+
+    dg_values = compute_batch_dimer_dg(dimer_pairs)
+
+    # Process results
+    assignments = {}
+    for i, (pair_key, probe, _, _) in enumerate(check_list):
+        dg_fwd = dg_values[2 * i] if dg_values[2 * i] is not None else 0.0
+        dg_rev = dg_values[2 * i + 1] if dg_values[2 * i + 1] is not None else 0.0
+        if dg_fwd > min_dg and dg_rev > min_dg:
+            assignments.setdefault(pair_key, []).append(probe)
+
+    return assignments
+
+
+def _run_probe_first(args, params, primer_params, cov_min, act_min, min_pairs, start_time):
+    """Probe-first quick mode: find conserved probe regions, then flanking primers."""
+    from Bio import AlignIO
+
+    min_amp_len = primer_params["min_amp_len"]
+    max_amp_len = primer_params["max_amp_len"]
+    min_dg = primer_params["min_dg"]
+    primer_len = primer_params["min_pri_len"]
+    min_gc = primer_params.get("min_gc", 30) / 100.0 if primer_params.get("min_gc") else 0.30
+    max_gc_frac = primer_params["max_gc"] / 100.0
+
+    top_pairs = int(params.get("QUICK_TOP_PAIRS", TOP_PAIRS))
+    n_variants = int(params.get("QUICK_N_VARIANTS", N_VARIANTS))
+
+    probe_params = get_probe_params(params)
+    buffer = int(params.get("PROBE_AMPLICON_BUFFER", 20))
+
+    print(f"Quick mode (probe-first): {args.name}")
+    print(f"  Thresholds: coverage >= {cov_min}, activity >= {act_min}")
+    print(f"  Probe: len {probe_params['len_min']}-{probe_params['len_max']}, "
+          f"Tm {probe_params['min_tm']}-{probe_params['max_tm']}, "
+          f"conservation >= {probe_params['conservation_threshold']}")
+
+    # Step 1: Load MSA
+    print("Step 1: Loading MSA...")
+    aln = AlignIO.read(args.msa, "fasta-pearson")
+    raw_seqs = [str(r.seq) for r in aln]
+    all_seq_ids = [r.id for r in aln]
+    n_raw_cols = len(raw_seqs[0])
+
+    # Pre-filter gap-dominant columns
+    gap_thresh = 0.50
+    n_seqs_raw = len(raw_seqs)
+    _msa_arr = np.array([list(s) for s in raw_seqs], dtype='U1')
+    _gap_counts = np.sum((_msa_arr == '-') | (_msa_arr == 'N') | (_msa_arr == 'n'), axis=0)
+    keep_mask = (_gap_counts / n_seqs_raw) <= gap_thresh
+    kept_indices = np.where(keep_mask)[0]
+    _kept_arr = _msa_arr[:, kept_indices]
+    aligned_seqs = [''.join(row) for row in _kept_arr]
+    del _msa_arr, _kept_arr
+    n_kept = int(keep_mask.sum())
+    print(f"  MSA: {len(aligned_seqs)} seqs, {n_raw_cols} columns → "
+          f"{n_kept} after removing {n_raw_cols - n_kept} gap-dominant columns")
+
+    # Step 2: Find conserved probe regions
+    # Cap region width so flanking primers fit within amplicon constraints
+    print("Step 2: Scanning for conserved probe regions...")
+    probe_regions = _find_probe_regions_msa(aligned_seqs, probe_params)
+    if not probe_regions:
+        print("WARNING: No probe regions found (even with relaxed fallback). "
+              "Falling back to primer-only mode.")
+        print("  Suggestions: increase PROBE_MAX_MISMATCHES or lower fallback_min_coverage")
+        if args.probe_fa:
+            Path(args.probe_fa).parent.mkdir(parents=True, exist_ok=True)
+            Path(args.probe_fa).touch()
+        if args.probe_feat:
+            Path(args.probe_feat).parent.mkdir(parents=True, exist_ok=True)
+            Path(args.probe_feat).touch()
+        return _run_multi_region(args, params, primer_params, cov_min, act_min, min_pairs, start_time)
+
+    print(f"  Found {len(probe_regions)} conserved probe regions:")
+    for i, (s, e, nv) in enumerate(probe_regions):
+        print(f"    Region {i+1}: MSA cols {s}-{e} ({e-s} bp, {nv} variable sites)")
+
+    # Step 3: Generate probe candidates across all regions
+    print("Step 3: Generating probe candidates...")
+    probes, probe_features = _generate_probes_from_msa(aligned_seqs, probe_regions, probe_params)
+    if not probes:
+        print("WARNING: No probes passed filters. Falling back to primer-only mode.")
+        if args.probe_fa:
+            Path(args.probe_fa).parent.mkdir(parents=True, exist_ok=True)
+            Path(args.probe_fa).touch()
+        if args.probe_feat:
+            Path(args.probe_feat).parent.mkdir(parents=True, exist_ok=True)
+            Path(args.probe_feat).touch()
+        return _run_multi_region(args, params, primer_params, cov_min, act_min, min_pairs, start_time)
+
+    print(f"  Generated {len(probes)} probe candidates")
+
+    # Step 3b: Score probes by per-sequence conservation and select top N
+    max_mm = probe_params["max_mismatches"]
+    top_n_probes = int(params.get("PROBE_TOP_N", 20))
+    print(f"  Scoring probes by sequence coverage (≤{max_mm} mismatches)...")
+    _score_probes_by_coverage(probes, aligned_seqs, max_mm)
+
+    selected_probes = _select_top_probes(probes, top_n=top_n_probes, min_distance=30)
+    print(f"  Selected {len(selected_probes)} probes at distinct positions:")
+    for i, p in enumerate(selected_probes):
+        print(f"    Probe {i+1}: {p['name']} ({p['seq'][:20]}...) "
+              f"MSA {p['msa_start']}-{p['msa_end']}, "
+              f"coverage={p['coverage']:.1%}, Tm={p['tm']}")
+
+    # Update probe_features to only include selected probes
+    selected_names = {p['name'] for p in selected_probes}
+    probe_features = {k: v for k, v in probe_features.items() if k in selected_names}
+
+    # Build probes_by_probe_idx for dimer checking later
+    probes_by_probe_idx = {i: [p] for i, p in enumerate(selected_probes)}
+
+    # Write probe mapping CSV directly from MSA (replaces build_index + align_probes + parse_probe_mapping)
+    if getattr(args, 'probe_csv', None):
+        _write_probe_mapping_csv(
+            selected_probes, aligned_seqs, all_seq_ids,
+            args.probe_csv, max_mm,
+        )
+
+    # Step 4: Compute primer conservation and find flanking positions
+    print("Step 4: Scoring flanking primer positions...")
+    scored, consensus_aligned, kept_cols = score_amplicon_positions(
+        aligned_seqs, primer_len, min_amp_len, max_amp_len,
+        min_gc=min_gc, max_gc=max_gc_frac,
+        top_n=0,
+    )
+
+    # Compute wobble-aware identity per column
+    seq_len = len(aligned_seqs[0])
+    _msa = np.array([list(s.upper()) for s in aligned_seqs], dtype='U1')
+    _base_A = (_msa == 'A').sum(axis=0)
+    _base_T = (_msa == 'T').sum(axis=0)
+    _base_G = (_msa == 'G').sum(axis=0)
+    _base_C = (_msa == 'C').sum(axis=0)
+    _n_bases = _base_A + _base_T + _base_G + _base_C
+    _gap_counts_col = ((_msa == '-') | (_msa == 'N')).sum(axis=0)
+    n_seqs = len(aligned_seqs)
+
+    identity = np.zeros(seq_len, dtype=np.float64)
+    for col in range(seq_len):
+        if _n_bases[col] > 0 and (_gap_counts_col[col] / n_seqs) <= gap_thresh:
+            counts = {'A': int(_base_A[col]), 'T': int(_base_T[col]),
+                      'G': int(_base_G[col]), 'C': int(_base_C[col])}
+            sense_freqs = {b: c / n_seqs for b, c in counts.items() if c > 0}
+            anti_freqs = {_COMPLEMENT.get(b, b): f for b, f in sense_freqs.items()}
+            _, fwd_score = _best_primer_base(anti_freqs)
+            _, rev_score = _best_primer_base(sense_freqs)
+            identity[col] = max(fwd_score, rev_score)
+    del _msa, _base_A, _base_T, _base_G, _base_C, _n_bases, _gap_counts_col
+
+    positions_with_probe = _find_flanking_primer_positions(
+        selected_probes, identity, kept_cols,
+        primer_len, min_amp_len, max_amp_len, buffer,
+        min_gc=min_gc, max_gc=max_gc_frac,
+    )
+    if not positions_with_probe:
+        print("ERROR: No valid flanking primer positions found.")
+        Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.out).touch()
+        return
+
+    # Map probe_idx for each primer pair (a position can serve multiple probes)
+    primer_probe_map = {}  # (fwd, rev) -> set of probe_idxs
+    positions = [(f, r, s) for f, r, s, _ in positions_with_probe]
+    for f, r, s, probe_idx in positions_with_probe:
+        primer_probe_map.setdefault((f, r), set()).add(probe_idx)
+
+    print(f"  Found {len(positions)} flanking primer positions across "
+          f"{len(set(pi for _, _, _, pi in positions_with_probe))} probes")
+
+    # Step 5: Generate primer variants
+    print("Step 5: Generating wobble-optimized primer variants...")
+    primers, features = extract_primers_at_positions(
+        aligned_seqs, positions, primer_len,
+        primer_params["min_tm"], primer_params["max_tm"],
+        primer_params["max_gc"], min_dg,
+        n_variants=n_variants,
+        max_pri_len=primer_params["max_pri_len"],
+    )
+
+    if not primers:
+        print("ERROR: No primers passed Tm/GC/dG filters.")
+        Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.out).touch()
+        return
+
+    # Propagate probe_idxs to primers (set of all probes this position serves)
+    for p in primers:
+        key = (p['fwd_start_msa'], p['rev_start_msa'])
+        p['probe_idxs'] = primer_probe_map.get(key, set())
+
+    n_unique_pos = len(set(p['pos_idx'] for p in primers))
+    print(f"  Passed filters: {len(primers)} pairs ({n_unique_pos} positions)")
+
+    # Take top N by score
+    primers.sort(key=lambda p: -p['score'])
+    if len(primers) > top_pairs:
+        primers = primers[:top_pairs]
+    print(f"  Selected top {len(primers)} pairs")
+
+    # Step 6: Group into batches
+    print("Step 6: Grouping into batches...")
+    batches = group_into_batches(primers, primer_len)
+    for i, (batch, min_fwd, max_rev) in enumerate(batches):
+        print(f"  Batch {i+1}: {len(batch)} pairs, MSA {min_fwd}-{max_rev}")
+
+    # Step 7: Load ML models
+    print("Step 7: Loading ML models...")
+    scaler, classifier, regressor, device = load_models()
+    torch.set_num_threads(args.threads)
+
+    # Setup tmpdir
+    if args.tmpdir:
+        tmpdir = str(Path(args.tmpdir) / "_intermediate")
+    else:
+        tmpdir = str(Path(args.out).parent)
+    os.makedirs(tmpdir, exist_ok=True)
+
+    # Step 8: Per-batch evaluation loop
+    all_results = []
+    all_eval_re = []
+    all_eval_full = []
+    all_eval_cl = []
+    name_to_seq = {}
+    all_probe_assignments = {}
+    pair_to_probe_idx = {}  # (pname_f, pname_r) -> set of probe_idxs
+
+    try:
+        for batch_idx, (batch_primers, min_fwd, max_rev) in enumerate(batches):
+            batch_start = time.time()
+            print(f"\nBatch {batch_idx+1}/{len(batches)}: {len(batch_primers)} pairs, MSA {min_fwd}-{max_rev}")
+
+            # Extract bowtie2 reference
+            margin = 20
+            win_start = max(0, min_fwd - margin)
+            win_end = max_rev + margin
+            all_window = extract_window_sequences(aligned_seqs, all_seq_ids, win_start, win_end)
+            if not all_window:
+                print("  No sequences in region. Skipping.")
+                continue
+
+            win_target_fa = Path(tmpdir) / f"batch_{batch_idx}_targets.fa"
+            with open(win_target_fa, "w") as f:
+                for sid, seq in all_window:
+                    f.write(f">{sid}\n{seq}\n")
+            n_targets = len(all_window)
+
+            # Build bowtie2 index
+            index_prefix = str(Path(tmpdir) / f"batch_{batch_idx}_bt2idx")
+            print("  Building bowtie2 index...", end=" ", flush=True)
+            build_index(str(win_target_fa), index_prefix, threads=args.threads)
+            print("done.")
+
+            # Write batch FASTA and features
+            fwd_seqs = [p['fwd_seq'] for p in batch_primers]
+            rev_seqs = [p['rev_seq'] for p in batch_primers]
+            fasta_path, feat_path, fwd_n2s, rev_n2s = _write_batch_fasta_and_features(
+                fwd_seqs, rev_seqs, features, args.name, batch_idx, tmpdir
+            )
+            name_to_seq.update(fwd_n2s)
+            name_to_seq.update(rev_n2s)
+
+            # Map primer pair names to probe_idx
+            for i, p in enumerate(batch_primers):
+                pname_f = f"{args.name}_q{batch_idx}_{i+1}_f"
+                pname_r = f"{args.name}_q{batch_idx}_{i+1}_r"
+                pair_to_probe_idx[(pname_f, pname_r)] = p.get('probe_idxs', set())
+
+            # Align
+            print("  Aligning...", end=" ", flush=True)
+            mapped_path = _align_batch(
+                fasta_path, index_prefix, n_targets, args.threads, tmpdir, batch_idx
+            )
+            print("done.")
+
+            if mapped_path.stat().st_size == 0:
+                print("  No alignments found. Skipping.")
+                continue
+
+            # Coverage filter
+            filtered_path = _apply_coverage_filter(mapped_path, n_targets, tmpdir, batch_idx, cov_frac=0.90)
+            if filtered_path.stat().st_size == 0:
+                print("  No primers pass coverage filter. Skipping.")
+                continue
+
+            # Prepare ML input
+            print("  Preparing ML input...", end=" ", flush=True)
+            input_path = Path(tmpdir) / f"batch_{batch_idx}.input"
+            prep_args = argparse.Namespace(
+                mapped=str(filtered_path),
+                ml_input=str(input_path),
+                reference=str(win_target_fa),
+                param_file=args.param_file,
+                reftype="on",
+                pri_features=str(feat_path),
+                prev="",
+            )
+            try:
+                run_prepare_input(prep_args)
+            except SystemExit:
+                pass
+            print("done.")
+
+            if not input_path.exists() or input_path.stat().st_size == 0:
+                print("  No valid pairs formed. Skipping.")
+                continue
+
+            # ML evaluate
+            print("  Evaluating...", end=" ", flush=True)
+            res, eval_re, eval_full, eval_cl = _run_evaluate(
+                input_path, str(win_target_fa), scaler, classifier, regressor, device, args.threads,
+                n_targets_global=len(aligned_seqs),
+            )
+            print("done.")
+
+            if res.empty:
+                print("  No results. Skipping.")
+                continue
+
+            # Probe-primer dimer check
+            batch_probe_idxs = set()
+            for p in batch_primers:
+                batch_probe_idxs.update(p.get('probe_idxs', set()))
+            batch_probes = []
+            for pi in batch_probe_idxs:
+                batch_probes.extend(probes_by_probe_idx.get(pi, []))
+
+            if batch_probes:
+                print(f"  Checking probe-primer dimers ({len(batch_probes)} probes)...", end=" ", flush=True)
+                assignments = _check_probe_primer_dimers(res, batch_probes, name_to_seq, min_dg=min_dg)
+                all_probe_assignments.update(assignments)
+                n_with_probes = sum(1 for _, row in res.iterrows()
+                                   if (row['pname_f'], row['pname_r']) in assignments)
+                print(f"{n_with_probes}/{len(res)} pairs have compatible probes.")
+
+            all_results.append(res)
+            all_eval_re.append(eval_re)
+            if not eval_full.empty:
+                all_eval_full.append(eval_full)
+            if not eval_cl.empty:
+                all_eval_cl.append(eval_cl)
+            batch_time = time.time() - batch_start
+
+            passing = res[(res["coverage"] >= cov_min) & (res["activity"] >= act_min)]
+            total_passing = sum(
+                len(r[(r["coverage"] >= cov_min) & (r["activity"] >= act_min)])
+                for r in all_results
+            )
+            top = res.iloc[0]
+            print(f"  Top pair: coverage={top['coverage']:.3f}, activity={top['activity']:.3f}, score={top['score']:.3f}")
+            print(f"  Pairs meeting thresholds: {len(passing)} (total: {total_passing}/{min_pairs})")
+            print(f"  Batch time: {batch_time:.1f}s")
+
+            if total_passing >= min_pairs:
+                print(f"\n  SUCCESS! Found {total_passing} pairs meeting thresholds (target: {min_pairs}).")
+                break
+
+        # Write outputs
+        probe_data = {
+            'probes': probes,
+            'features': probe_features,
+            'assignments': all_probe_assignments,
+        }
+        _write_output(args, all_results, all_eval_re, name_to_seq,
+                      cov_min, act_min, len(batches), tmpdir, min_dg=min_dg,
+                      features=features, probe_data=probe_data,
+                      all_eval_full=all_eval_full, all_eval_cl=all_eval_cl,
+                      pair_to_probe_idx=pair_to_probe_idx)
+
+    finally:
+        print(f"  Temp files kept at: {tmpdir}")
+
+    runtime = time.time() - start_time
+    print(f"\nProbe-first quick mode completed in {runtime:.1f}s")
+
+
+def _run_multi_region(args, params, primer_params, cov_min, act_min, min_pairs, start_time):
+    """Position-first quick mode: score positions globally, extract primers, batch evaluate."""
+    from Bio import AlignIO
+
+    min_amp_len = primer_params["min_amp_len"]
+    max_amp_len = primer_params["max_amp_len"]
+    min_dg = primer_params["min_dg"]
+    primer_len = primer_params["min_pri_len"]
+    min_gc = primer_params.get("min_gc", 30) / 100.0 if primer_params.get("min_gc") else 0.30
+    max_gc_frac = primer_params["max_gc"] / 100.0
+
+    top_pairs = int(params.get("QUICK_TOP_PAIRS", TOP_PAIRS))
+
+    n_positions = int(params.get("QUICK_N_POSITIONS", N_POSITIONS))
+    n_variants = int(params.get("QUICK_N_VARIANTS", N_VARIANTS))
+
+    print(f"Quick mode (wobble-optimized): {args.name}")
+    print(f"  Thresholds: coverage >= {cov_min}, activity >= {act_min}")
+    print(f"  Positions: {n_positions}, variants/direction: {n_variants}")
+    print(f"  Max pairs: {n_positions} × {n_variants}² = {n_positions * n_variants**2}")
+
+    # Step 1: Load MSA, strip gap-dominant columns, and score amplicon positions
+    print("Step 1: Scoring amplicon positions across MSA...")
+    aln = AlignIO.read(args.msa, "fasta-pearson")
+    raw_seqs = [str(r.seq) for r in aln]
+    all_seq_ids = [r.id for r in aln]
+    n_raw_cols = len(raw_seqs[0])
+
+    # Pre-filter: remove columns where gap fraction > 0.50
+    gap_thresh = 0.50
+    n_seqs_raw = len(raw_seqs)
+    # Vectorize: convert MSA to numpy array of bytes for fast column ops
+    _msa_arr = np.array([list(s) for s in raw_seqs], dtype='U1')
+    _gap_counts = np.sum((_msa_arr == '-') | (_msa_arr == 'N') | (_msa_arr == 'n'), axis=0)
+    keep_mask = (_gap_counts / n_seqs_raw) <= gap_thresh
+    kept_indices = np.where(keep_mask)[0]
+    _kept_arr = _msa_arr[:, kept_indices]
+    aligned_seqs = [''.join(row) for row in _kept_arr]
+    del _msa_arr, _kept_arr  # free memory
+    n_kept = int(keep_mask.sum())
+    print(f"  MSA: {len(aligned_seqs)} seqs, {n_raw_cols} columns → "
+          f"{n_kept} after removing {n_raw_cols - n_kept} gap-dominant columns")
+
+    scored, consensus_aligned, kept_cols = score_amplicon_positions(
+        aligned_seqs, primer_len, min_amp_len, max_amp_len,
+        min_gc=min_gc, max_gc=max_gc_frac,
+        top_n=n_positions,
+    )
+    if not scored:
+        print("ERROR: No valid amplicon positions found in MSA.")
+        Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.out).touch()
+        return
+
+    print(f"  Top amplicon positions: {len(scored)}")
+    for i, (fwd, rev, score) in enumerate(scored[:5]):
+        print(f"    #{i+1}: fwd={fwd} rev={rev} (score={score:.4f})")
+
+    # Step 2: Generate wobble-optimized primer variants
+    print("Step 2: Generating wobble-optimized primer variants...")
+    primers, features = extract_primers_at_positions(
+        aligned_seqs, scored, primer_len,
+        primer_params["min_tm"], primer_params["max_tm"],
+        primer_params["max_gc"], min_dg,
+        n_variants=n_variants,
+        max_pri_len=primer_params["max_pri_len"],
+    )
+
+    if not primers:
+        print("ERROR: No primers passed Tm/GC/dG filters at any position.")
+        Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.out).touch()
+        return
+
+    n_unique_pos = len(set(p['pos_idx'] for p in primers))
+    print(f"  Passed Tm/GC/dG: {len(primers)} pairs ({n_unique_pos} positions)")
+
+    # Take top N pairs by score
+    primers.sort(key=lambda p: -p['score'])
+    if len(primers) > top_pairs:
+        primers = primers[:top_pairs]
+    n_unique_pos = len(set(p['pos_idx'] for p in primers))
+    print(f"  Selected top {len(primers)} pairs ({n_unique_pos} positions)")
+
+    # Step 4: Group into batches
+    print("Step 4: Grouping into batches...")
+    batches = group_into_batches(primers, primer_len)
+    for i, (batch, min_fwd, max_rev) in enumerate(batches):
+        print(f"  Batch {i+1}: {len(batch)} pairs, MSA {min_fwd}-{max_rev}")
+
+    # Step 5: Load ML models once
+    print("Step 5: Loading ML models...")
+    scaler, classifier, regressor, device = load_models()
+    torch.set_num_threads(args.threads)
+
+    # Setup tmpdir
+    if args.tmpdir:
+        tmpdir = str(Path(args.tmpdir) / "_intermediate")
+    else:
+        tmpdir = str(Path(args.out).parent)
+    os.makedirs(tmpdir, exist_ok=True)
+
+    # Step 6: Per-batch loop
+    all_results = []
+    all_eval_re = []
+    all_eval_full = []
+    all_eval_cl = []
+    name_to_seq = {}
+
+    try:
+        for batch_idx, (batch_primers, min_fwd, max_rev) in enumerate(batches):
+            batch_start = time.time()
+            print(f"\nBatch {batch_idx+1}/{len(batches)}: {len(batch_primers)} pairs, MSA {min_fwd}-{max_rev}")
+
+            # Extract bowtie2 reference for this batch's region
+            margin = 20
+            win_start = max(0, min_fwd - margin)
+            win_end = max_rev + margin
+            all_window = extract_window_sequences(aligned_seqs, all_seq_ids, win_start, win_end)
+            if not all_window:
+                print("  No sequences in region. Skipping.")
+                continue
+
+            win_target_fa = Path(tmpdir) / f"batch_{batch_idx}_targets.fa"
+            with open(win_target_fa, "w") as f:
+                for sid, seq in all_window:
+                    f.write(f">{sid}\n{seq}\n")
+            n_targets = len(all_window)
+            print(f"  Target sequences: {n_targets}")
+
+            # Build bowtie2 index
+            index_prefix = str(Path(tmpdir) / f"batch_{batch_idx}_bt2idx")
+            print("  Building bowtie2 index...", end=" ", flush=True)
+            build_index(str(win_target_fa), index_prefix, threads=args.threads)
+            print("done.")
+
+            # Write batch FASTA and features
+            fwd_seqs = [p['fwd_seq'] for p in batch_primers]
+            rev_seqs = [p['rev_seq'] for p in batch_primers]
+            fasta_path, feat_path, fwd_n2s, rev_n2s = _write_batch_fasta_and_features(
+                fwd_seqs, rev_seqs, features, args.name, batch_idx, tmpdir
+            )
+
+            name_to_seq.update(fwd_n2s)
+            name_to_seq.update(rev_n2s)
+
+            # Align
+            print("  Aligning...", end=" ", flush=True)
+            mapped_path = _align_batch(
+                fasta_path, index_prefix, n_targets, args.threads, tmpdir, batch_idx
+            )
+            print("done.")
+
+            if mapped_path.stat().st_size == 0:
+                print("  No alignments found. Skipping.")
+                continue
+
+            # Coverage filter
+            filtered_path = _apply_coverage_filter(mapped_path, n_targets, tmpdir, batch_idx, cov_frac=0.90)
+            if filtered_path.stat().st_size == 0:
+                print("  No primers pass coverage filter. Skipping.")
+                continue
+
+            # Prepare input
+            print("  Preparing ML input...", end=" ", flush=True)
+            input_path = Path(tmpdir) / f"batch_{batch_idx}.input"
+            prep_args = argparse.Namespace(
+                mapped=str(filtered_path),
+                ml_input=str(input_path),
+                reference=str(win_target_fa),
+                param_file=args.param_file,
+                reftype="on",
+                pri_features=str(feat_path),
+                prev="",
+            )
+            try:
+                run_prepare_input(prep_args)
+            except SystemExit:
+                pass
+            print("done.")
+
+            if not input_path.exists() or input_path.stat().st_size == 0:
+                print("  No valid pairs formed. Skipping.")
+                continue
+
+            # Evaluate
+            print("  Evaluating...", end=" ", flush=True)
+            res, eval_re, eval_full, eval_cl = _run_evaluate(
+                input_path, str(win_target_fa), scaler, classifier, regressor, device, args.threads,
+                n_targets_global=len(aligned_seqs),
+            )
+            print("done.")
+
+            if res.empty:
+                print("  No results. Skipping.")
+                continue
+
+            all_results.append(res)
+            all_eval_re.append(eval_re)
+            if not eval_full.empty:
+                all_eval_full.append(eval_full)
+            if not eval_cl.empty:
+                all_eval_cl.append(eval_cl)
+            batch_time = time.time() - batch_start
+
+            passing = res[(res["coverage"] >= cov_min) & (res["activity"] >= act_min)]
+            total_passing = sum(
+                len(r[(r["coverage"] >= cov_min) & (r["activity"] >= act_min)])
+                for r in all_results
+            )
+            top = res.iloc[0]
+            print(f"  Top pair: coverage={top['coverage']:.3f}, activity={top['activity']:.3f}, score={top['score']:.3f}")
+            print(f"  Pairs meeting thresholds: {len(passing)} (total: {total_passing}/{min_pairs})")
+            print(f"  Batch time: {batch_time:.1f}s")
+
+            if total_passing >= min_pairs:
+                print(f"\n  SUCCESS! Found {total_passing} pairs meeting thresholds (target: {min_pairs}).")
+                break
+
+        # Output results
+        _write_output(args, all_results, all_eval_re, name_to_seq,
+                      cov_min, act_min, len(batches), tmpdir, min_dg=min_dg,
+                      features=features, all_eval_full=all_eval_full,
+                      all_eval_cl=all_eval_cl)
+
+    finally:
+        print(f"  Temp files kept at: {tmpdir}")
+
+    runtime = time.time() - start_time
+    print(f"\nQuick mode completed in {runtime:.1f}s")
+
+
+def _run_single_window(args, params, primer_params, cov_min, act_min, min_pairs, start_time):
+    """Legacy single-window quick mode (when --msa is not provided)."""
+    if not args.selected:
+        raise SystemExit("ERROR: --selected is required when --msa is not provided.")
+    min_amp_len = primer_params["min_amp_len"]
+    max_amp_len = primer_params["max_amp_len"]
+    min_dg = primer_params["min_dg"]
+
+    print(f"Quick mode: {args.name}")
+    print(f"  Thresholds: coverage >= {cov_min}, activity >= {act_min}")
+    print(f"  Max batches: {MAX_BATCHES}, primers/batch: {PRIMERS_PER_BATCH} per direction")
+
+    # Determine which FASTA to use for bowtie2 indexing
+    bt2_ref = args.target_window if args.target_window else args.target
+    n_targets = sum(1 for _ in SeqIO.parse(bt2_ref, "fasta"))
+    print(f"  Target sequences: {n_targets}")
+    if args.target_window:
+        print(f"  Using window-trimmed reference for bowtie2 index")
+
+    # Step 1: Generate all primers from selected sequences
+    print("Step 1: Generating primers...")
+    selected_records = list(SeqIO.parse(args.selected, "fasta"))
+    target_seqs = [sanitize_iupac(str(r.seq)) for r in selected_records]
+
+    raw_weights = {}
+    for idx, rec in enumerate(selected_records):
+        frac = 1.0
+        if "cluster_frac=" in rec.description:
+            try:
+                frac = float(rec.description.split("cluster_frac=")[1].split()[0])
+            except (ValueError, IndexError):
+                pass
+        raw_weights[idx] = frac
+
+    medoid_total = sum(w for w in raw_weights.values() if w > 0)
+    origin_weights = {}
+    for idx, w in raw_weights.items():
+        if w == 0.0:
+            origin_weights[idx] = CONSENSUS_QUOTA_FRAC
+        else:
+            origin_weights[idx] = w / medoid_total * (1.0 - CONSENSUS_QUOTA_FRAC)
+
+    for_filt, rev_filt, features = generate_primers_multi(
+        target_seqs,
+        primer_params["step"],
+        primer_params["min_pri_len"],
+        primer_params["max_pri_len"],
+        min_amp_len,
+        max_amp_len,
+        primer_params["max_tm"],
+        primer_params["min_tm"],
+        primer_params["max_gc"],
+        min_dg,
+    )
+
+    if not for_filt or not rev_filt:
+        print("ERROR: No primers passed filters. Cannot proceed.")
+        Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.out).touch()
+        return
+
+    print(f"  Generated: {len(for_filt)} fwd, {len(rev_filt)} rev primers")
+
+    # Step 2: Build origin map and compute position bins
+    print("Step 2: Tracking primer origins and computing position bins...")
+    origin_map = _build_origin_map(
+        target_seqs, for_filt, rev_filt,
+        primer_params["step"], primer_params["min_pri_len"],
+        primer_params["max_pri_len"], min_amp_len,
+    )
+    n_origins = len(target_seqs)
+    cons_idx = n_origins - 1
+    cons_fwd_count = sum(1 for s in for_filt if cons_idx in origin_map.get(s, set()))
+    cons_rev_count = sum(1 for s in rev_filt if cons_idx in origin_map.get(s, set()))
+    print(f"  Origins: {n_origins} sequences ({n_origins-1} representatives + 1 consensus)")
+    print(f"  Consensus primers: {cons_fwd_count} fwd, {cons_rev_count} rev")
+    total_w = sum(origin_weights.values())
+    for idx in range(n_origins):
+        w = origin_weights[idx]
+        q = max(1, int(round(PRIMERS_PER_BATCH * w / total_w)))
+        label = "consensus" if idx == cons_idx else f"rep_{idx}"
+        print(f"  Origin {label}: weight={w:.4f}, quota~{q}")
+
+    position_bins = _compute_position_bins(for_filt, MAX_BATCHES)
+    for i, (bs, be) in enumerate(position_bins):
+        n_f = sum(1 for _, p in for_filt.items() if bs <= p < be)
+        print(f"  Bin {i+1}: positions {int(bs)}-{int(be)}, {n_f} fwd primers")
+
+    if not position_bins:
+        print("ERROR: No valid primer positions. Try adjusting amplicon length constraints.")
+        Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.out).touch()
+        return
+
+    # Step 3: Build bowtie2 index
+    print("Step 3: Building bowtie2 index...")
+    if args.tmpdir:
+        tmpdir = str(Path(args.tmpdir) / "_intermediate")
+    else:
+        tmpdir = str(Path(args.out).parent)
+    os.makedirs(tmpdir, exist_ok=True)
+    index_prefix = str(Path(tmpdir) / "bt2idx")
+    build_index(bt2_ref, index_prefix, threads=args.threads)
+
+    # Step 4: Load ML models once
+    print("Step 4: Loading ML models...")
+    scaler, classifier, regressor, device = load_models()
+    torch.set_num_threads(args.threads)
+
+    # Step 5: Batch loop
+    all_results = []
+    all_eval_re = []
+    all_eval_full = []
+    all_eval_cl = []
+    best_result = None
+    name_to_seq = {}
+
+    try:
+        for batch_idx, (bin_start, bin_end) in enumerate(position_bins):
+            batch_start_time = time.time()
+
+            fwd_selected, rev_selected = _select_batch_primers(
+                for_filt, rev_filt, features, origin_map,
+                n_origins, origin_weights, bin_start, bin_end,
+                min_amp_len, max_amp_len,
+            )
+
+            if not fwd_selected or not rev_selected:
+                print(f"\nBatch {batch_idx+1}/{MAX_BATCHES}: No primers in bin {int(bin_start)}-{int(bin_end)}. Skipping.")
+                continue
+
+            n_cons_f = sum(1 for s in fwd_selected if cons_idx in origin_map.get(s, set()))
+            n_cons_r = sum(1 for s in rev_selected if cons_idx in origin_map.get(s, set()))
+            n_rep_f = len(fwd_selected) - n_cons_f
+            n_rep_r = len(rev_selected) - n_cons_r
+            print(f"\nBatch {batch_idx+1}/{MAX_BATCHES}: positions {int(bin_start)}-{int(bin_end)}")
+            print(f"  {len(fwd_selected)} fwd ({n_cons_f} cons + {n_rep_f} rep), {len(rev_selected)} rev ({n_cons_r} cons + {n_rep_r} rep)")
+            print(f"  Up to {len(fwd_selected) * len(rev_selected)} cross-pairs")
+
+            fasta_path, feat_path, fwd_n2s, rev_n2s = _write_batch_fasta_and_features(
+                fwd_selected, rev_selected, features, args.name, batch_idx, tmpdir
+            )
+
+            name_to_seq.update(fwd_n2s)
+            name_to_seq.update(rev_n2s)
+
+            print("  Aligning...", end=" ", flush=True)
+            mapped_path = _align_batch(
+                fasta_path, index_prefix, n_targets, args.threads, tmpdir, batch_idx
+            )
+            print("done.")
+
+            if mapped_path.stat().st_size == 0:
+                print("  No alignments found. Skipping batch.")
+                continue
+
+            filtered_path = _apply_coverage_filter(mapped_path, n_targets, tmpdir, batch_idx)
+            if filtered_path.stat().st_size == 0:
+                print("  No primers pass coverage filter. Skipping batch.")
+                continue
+
+            print("  Preparing ML input...", end=" ", flush=True)
+            input_path = Path(tmpdir) / f"batch_{batch_idx}.input"
+            prep_args = argparse.Namespace(
+                mapped=str(filtered_path),
+                ml_input=str(input_path),
+                reference=bt2_ref,
+                param_file=args.param_file,
+                reftype="on",
+                pri_features=str(feat_path),
+                prev="",
+            )
+            try:
+                run_prepare_input(prep_args)
+            except SystemExit:
+                pass
+            print("done.")
+
+            if not input_path.exists() or input_path.stat().st_size == 0:
+                print("  No valid pairs formed. Skipping batch.")
+                continue
+
+            print("  Evaluating...", end=" ", flush=True)
+            res, eval_re, eval_full, eval_cl = _run_evaluate(
+                input_path, bt2_ref, scaler, classifier, regressor, device, args.threads
+            )
+            print("done.")
+
+            if res.empty:
+                print("  No results. Skipping batch.")
+                continue
+
+            all_results.append(res)
+            all_eval_re.append(eval_re)
+            if not eval_full.empty:
+                all_eval_full.append(eval_full)
+            if not eval_cl.empty:
+                all_eval_cl.append(eval_cl)
+            batch_time = time.time() - batch_start_time
+
+            passing = res[(res["coverage"] >= cov_min) & (res["activity"] >= act_min)]
+            total_passing = sum(
+                len(r[(r["coverage"] >= cov_min) & (r["activity"] >= act_min)])
+                for r in all_results
+            )
+            top = res.iloc[0]
+            print(f"  Top pair: coverage={top['coverage']:.3f}, activity={top['activity']:.3f}, score={top['score']:.3f}")
+            print(f"  Pairs meeting thresholds: {len(passing)} (total: {total_passing}/{min_pairs})")
+            print(f"  Batch time: {batch_time:.1f}s")
+
+            if total_passing >= min_pairs:
+                print(f"\n  SUCCESS! Found {total_passing} pairs meeting thresholds (target: {min_pairs}).")
+                best_result = passing
+                break
+            elif not passing.empty:
+                best_result = passing
+            else:
+                if best_result is None or top["score"] > best_result.iloc[0]["score"]:
+                    best_result = res
+
+        # Output results
+        _write_output(args, all_results, all_eval_re, name_to_seq,
+                      cov_min, act_min, MAX_BATCHES, tmpdir, min_dg=min_dg,
+                      features=features, all_eval_full=all_eval_full,
+                      all_eval_cl=all_eval_cl)
+
+    finally:
+        print(f"  Temp files kept at: {tmpdir}")
+
+    runtime = time.time() - start_time
+    print(f"\nQuick mode completed in {runtime:.1f}s")
+
+
+def _write_probe_outputs(args, combined, probe_data):
+    """Write probe FASTA and features files for probe-first mode."""
+    assignments = probe_data.get('assignments', {})
+    all_probes = probe_data.get('probes', [])
+    probe_features = probe_data.get('features', {})
+
+    # Collect probes assigned to at least one passing pair
+    used_probe_names = set()
+    for _, row in combined.iterrows():
+        pair_key = (row['pname_f'], row['pname_r'])
+        for probe in assignments.get(pair_key, []):
+            used_probe_names.add(probe['name'])
+
+    # If no assignments, include all probes (downstream filter will re-check)
+    if not used_probe_names:
+        used_probe_names = {p['name'] for p in all_probes}
+
+    # Write probe FASTA
+    if args.probe_fa:
+        Path(args.probe_fa).parent.mkdir(parents=True, exist_ok=True)
+        written = set()
+        with open(args.probe_fa, "w") as f:
+            for probe in all_probes:
+                if probe['name'] in used_probe_names and probe['name'] not in written:
+                    f.write(f">{probe['name']}\n{probe['seq']}\n")
+                    written.add(probe['name'])
+        print(f"  Saved probe FASTA: {args.probe_fa} ({len(written)} probes)")
+
+    # Write probe features
+    if args.probe_feat:
+        Path(args.probe_feat).parent.mkdir(parents=True, exist_ok=True)
+        feat_rows = []
+        seen = set()
+        for probe in all_probes:
+            if probe['name'] in used_probe_names and probe['name'] not in seen:
+                seen.add(probe['name'])
+                feat_rows.append({
+                    'pname': probe['name'],
+                    'pseq': probe['seq'],
+                    'len': len(probe['seq']),
+                    'position': probe['msa_start'],
+                    'Tm': probe['tm'],
+                    'GC': probe['gc'],
+                    'dG': probe['dg'],
+                })
+        pd.DataFrame(feat_rows).to_csv(args.probe_feat, index=False)
+        print(f"  Saved probe features: {args.probe_feat} ({len(feat_rows)} probes)")
+
+
+def _write_output(args, all_results, all_eval_re, name_to_seq,
+                   cov_min, act_min, n_batches, tmpdir, min_dg=-7.0,
+                   features=None, probe_data=None, all_eval_full=None,
+                   all_eval_cl=None, pair_to_probe_idx=None):
+    """Write combined output from all batches/windows."""
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+
+    if all_results:
+        combined = pd.concat(all_results, ignore_index=True)
+        combined = combined.sort_values("activity", ascending=False).drop_duplicates(
+            subset=["pname_f", "pname_r"]
+        )
+
+        combined = combined[combined["coverage"] > 0]
+        if combined.empty:
+            Path(args.out).touch()
+            print("\nWARNING: All pairs had coverage=0. Recommend running full mode.")
+        else:
+            combined["fwd_seq"] = combined["pname_f"].map(name_to_seq)
+            combined["rev_seq"] = combined["pname_r"].map(name_to_seq)
+
+            # Cross-dimer dG filter for cross-position pairs
+            n_before = len(combined)
+            cross_pairs = list(zip(combined["fwd_seq"], combined["rev_seq"]))
+            cross_dgs = compute_batch_dimer_dg(cross_pairs)
+            combined["cross_dg"] = cross_dgs
+            combined = combined[combined["cross_dg"] >= min_dg].drop(columns=["cross_dg"])
+            n_dropped = n_before - len(combined)
+            if n_dropped > 0:
+                print(f"  Cross-dimer dG filter: dropped {n_dropped}/{n_before} pairs (min_dg={min_dg})")
+
+            # Probe mode: keep all passing pairs — dedup happens in build-output
+            if pair_to_probe_idx:
+                combined = combined.sort_values("score", ascending=False)
+
+            cols = ["pname_f", "pname_r", "fwd_seq", "rev_seq", "coverage", "activity", "score"]
+            combined = combined[[c for c in cols if c in combined.columns]]
+            # Pipeline mode: eval file must have only pname_f,pname_r,coverage,activity,score
+            if getattr(args, 'init_fa', None):
+                combined[["pname_f", "pname_r", "coverage", "activity", "score"]].to_csv(
+                    args.out, index=False)
+                # Write marker so filter_primers knows to skip position validation
+                Path(f"{args.out}.quick").touch()
+            else:
+                combined.to_csv(args.out, index=False)
+
+            # Write pipeline-compatible init FASTA (all primers in results)
+            if getattr(args, 'init_fa', None):
+                Path(args.init_fa).parent.mkdir(parents=True, exist_ok=True)
+                seen_seqs = set()
+                with open(args.init_fa, "w") as f:
+                    for _, row in combined.iterrows():
+                        fname, rname = row["pname_f"], row["pname_r"]
+                        fseq, rseq = row["fwd_seq"], row["rev_seq"]
+                        if fname not in seen_seqs:
+                            f.write(f">{fname}\n{fseq}\n")
+                            seen_seqs.add(fname)
+                        if rname not in seen_seqs:
+                            f.write(f">{rname}\n{rseq}\n")
+                            seen_seqs.add(rname)
+                print(f"  Saved init FASTA: {args.init_fa}")
+
+            # Write pipeline-compatible features file
+            if getattr(args, 'init_feat', None):
+                Path(args.init_feat).parent.mkdir(parents=True, exist_ok=True)
+                feat_rows = []
+                seen_names = set()
+                for _, row in combined.iterrows():
+                    for pname, seq, forrev in [
+                        (row["pname_f"], row["fwd_seq"], "f"),
+                        (row["pname_r"], row["rev_seq"], "r"),
+                    ]:
+                        if pname in seen_names:
+                            continue
+                        seen_names.add(pname)
+                        feat = (features or {}).get(seq, {})
+                        feat_rows.append({
+                            "pname": pname, "pseq": seq, "forrev": forrev,
+                            "len": feat.get("len", len(seq)),
+                            "Tm": feat.get("Tm", 0),
+                            "GC": feat.get("GC", 0),
+                            "dG": feat.get("dG", 0),
+                        })
+                pd.DataFrame(feat_rows).to_csv(args.init_feat, index=False)
+                print(f"  Saved init features: {args.init_feat}")
+
+            # Write probe outputs (probe-first mode)
+            if probe_data and getattr(args, 'probe_fa', None):
+                _write_probe_outputs(args, combined, probe_data)
+
+        if all_eval_re:
+            eval_re_combined = pd.concat(all_eval_re, ignore_index=True)
+            eval_re_combined = eval_re_combined.fillna(0)
+            agg_dict = {c: "max" for c in eval_re_combined.columns[2:]}
+            eval_re_combined = eval_re_combined.groupby(
+                ["pname_f", "pname_r"]
+            ).agg(agg_dict).reset_index()
+            re_path = str(Path(tmpdir) / f"{args.name}.eval.re")
+            eval_re_combined.to_csv(re_path, index=False)
+            print(f"  Saved per-target activity: {re_path}")
+
+        if all_eval_full:
+            eval_full_combined = pd.concat(all_eval_full, ignore_index=True)
+            eval_full_path = f"{args.out}.full"
+            eval_full_combined.to_csv(eval_full_path, index=False)
+            print(f"  Saved eval full: {eval_full_path}")
+
+        if all_eval_cl:
+            eval_cl_combined = pd.concat(all_eval_cl, ignore_index=True)
+            agg_dict = {c: "max" for c in eval_cl_combined.columns[2:]}
+            eval_cl_combined = eval_cl_combined.groupby(
+                ["pname_f", "pname_r"]
+            ).agg(agg_dict).reset_index()
+            cl_path = f"{args.out}.cl"
+            eval_cl_combined.to_csv(cl_path, index=False)
+            print(f"  Saved classifier table: {cl_path}")
+
+        top = combined.iloc[0]
+        passes = (top["coverage"] >= cov_min) and (top["activity"] >= act_min)
+
+        if not passes:
+            print(f"\nWARNING: No pairs met thresholds after {n_batches} batches.")
+            print(f"  Best: coverage={top['coverage']:.3f}, activity={top['activity']:.3f}")
+            print(f"  Recommend running full mode: snakemake --cores N")
+    else:
+        Path(args.out).touch()
+        if getattr(args, 'init_fa', None):
+            Path(f"{args.out}.quick").touch()
+            Path(args.init_fa).parent.mkdir(parents=True, exist_ok=True)
+            Path(args.init_fa).touch()
+        if getattr(args, 'init_feat', None):
+            Path(args.init_feat).parent.mkdir(parents=True, exist_ok=True)
+            pd.DataFrame(columns=["pname", "pseq", "forrev", "len", "Tm", "GC", "dG"]).to_csv(
+                args.init_feat, index=False)
+        if getattr(args, 'probe_fa', None):
+            Path(args.probe_fa).parent.mkdir(parents=True, exist_ok=True)
+            Path(args.probe_fa).touch()
+        if getattr(args, 'probe_feat', None):
+            Path(args.probe_feat).parent.mkdir(parents=True, exist_ok=True)
+            Path(args.probe_feat).touch()
+        print("\nWARNING: No results produced. Recommend running full mode.")
+

--- a/src/qprimer_designer/utils/params.py
+++ b/src/qprimer_designer/utils/params.py
@@ -55,7 +55,7 @@ def get_primer_params(params: dict) -> dict:
     """Extract primer generation parameters from parsed params dict."""
     return {
         "max_num": int(params.get("MAX_PRIMER_CANDIDATES", 10000)),
-        "step": int(params.get("TILING_STEP", 1)),
+        "step": 1,
         "min_pri_len": int(params.get("PRIMER_LEN_MIN", 20)),
         "max_pri_len": int(params.get("PRIMER_LEN_MAX", 20)),
         "min_amp_len": int(params.get("AMPLEN_MIN", 60)),

--- a/src/qprimer_designer/utils/sequences.py
+++ b/src/qprimer_designer/utils/sequences.py
@@ -43,7 +43,7 @@ def sanitize_iupac(seq: str) -> str:
     so that primer/probe candidates overlapping those positions are
     filtered out by the existing 'N' checks.
     """
-    return _IUPAC_AMBIGUITY.sub('N', seq)
+    return _IUPAC_AMBIGUITY.sub('N', seq).upper()
 
 
 def has_homopolymer(seq: str, max_len: int) -> bool:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -16,7 +16,7 @@ from qprimer_designer.commands.pick_representatives import (
     MinHashFamily,
     HashConcatenation,
     NearNeighborLookup,
-    find_low_gap_window,
+    find_best_design_window,
     trim_to_window,
     cluster_sequences,
     select_medoids,
@@ -218,27 +218,27 @@ class TestHashConcatenation:
         assert isinstance(result, str)
 
 
-class TestFindLowGapWindow:
-    """Tests for find_low_gap_window."""
+class TestFindBestDesignWindow:
+    """Tests for find_best_design_window."""
 
     def test_no_gaps(self):
         seqs = ["ATCGATCG" * 30]
-        pos = find_low_gap_window(seqs, window_size=20)
+        pos = find_best_design_window(seqs, window_size=20, primer_len=5)
         assert pos >= 0
 
     def test_empty_seqs(self):
-        pos = find_low_gap_window([], window_size=20)
+        pos = find_best_design_window([], window_size=20, primer_len=5)
         assert pos == 0
 
     def test_gaps_at_start(self):
         """Should prefer window without gaps."""
         seqs = ["---ATCGATCGATCG" + "A" * 200]
-        pos = find_low_gap_window(seqs, window_size=10)
+        pos = find_best_design_window(seqs, window_size=10, primer_len=5)
         assert pos >= 3  # Should avoid the gap region
 
     def test_returns_integer(self):
         seqs = ["ATCG" * 100]
-        pos = find_low_gap_window(seqs, window_size=50)
+        pos = find_best_design_window(seqs, window_size=50, primer_len=5)
         assert isinstance(pos, int)
 
 

--- a/tests/test_generate_extended.py
+++ b/tests/test_generate_extended.py
@@ -14,7 +14,7 @@ from qprimer_designer.commands.generate import (
 class TestGeneratePrimersMulti:
     """Tests for generate_primers_multi (with mocked dG)."""
 
-    @patch("qprimer_designer.commands.generate.compute_self_dimer_dg", return_value=0.0)
+    @patch("qprimer_designer.commands.generate.compute_batch_dimer_dg", side_effect=lambda pairs: [0.0] * len(pairs))
     def test_basic_multi(self, mock_dg):
         """Test multi-target primer generation."""
         targets = ["ATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCG"]
@@ -32,7 +32,7 @@ class TestGeneratePrimersMulti:
             assert "len" in features[seq]
             assert "dG" in features[seq]
 
-    @patch("qprimer_designer.commands.generate.compute_self_dimer_dg", return_value=-100.0)
+    @patch("qprimer_designer.commands.generate.compute_batch_dimer_dg", side_effect=lambda pairs: [-100.0] * len(pairs))
     def test_dg_filter_removes_all(self, mock_dg):
         """All primers filtered when dG is below threshold."""
         targets = ["ATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCG"]
@@ -44,7 +44,7 @@ class TestGeneratePrimersMulti:
         assert len(for_filt) == 0
         assert len(rev_filt) == 0
 
-    @patch("qprimer_designer.commands.generate.compute_self_dimer_dg", return_value=0.0)
+    @patch("qprimer_designer.commands.generate.compute_batch_dimer_dg", side_effect=lambda pairs: [0.0] * len(pairs))
     def test_tm_filter(self, mock_dg):
         """Very narrow Tm range should filter out most primers."""
         targets = ["ATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCG"]
@@ -57,7 +57,7 @@ class TestGeneratePrimersMulti:
         # With Tm range [0, 0], almost no 20-mers will pass
         assert len(for_filt) == 0
 
-    @patch("qprimer_designer.commands.generate.compute_self_dimer_dg", return_value=0.0)
+    @patch("qprimer_designer.commands.generate.compute_batch_dimer_dg", side_effect=lambda pairs: [0.0] * len(pairs))
     def test_multiple_targets(self, mock_dg):
         """Test with multiple target sequences."""
         targets = [

--- a/tests/test_generate_probe.py
+++ b/tests/test_generate_probe.py
@@ -9,7 +9,7 @@ from qprimer_designer.commands.generate_probe import generate_probes
 class TestGenerateProbes:
     """Tests for generate_probes (with mocked dG computation)."""
 
-    @patch("qprimer_designer.commands.generate_probe.compute_self_dimer_dg", return_value=0.0)
+    @patch("qprimer_designer.commands.generate_probe.compute_batch_dimer_dg", side_effect=lambda pairs: [0.0] * len(pairs))
     def test_basic_generation(self, mock_dg):
         """Test basic probe generation from a target sequence."""
         target_seqs = ["ATCGATCGATCGATCGATCGATCGATCGATCGATCGATCG"]
@@ -27,7 +27,7 @@ class TestGenerateProbes:
             assert 8 <= len(seq) <= 10
             assert "N" not in seq
 
-    @patch("qprimer_designer.commands.generate_probe.compute_self_dimer_dg", return_value=0.0)
+    @patch("qprimer_designer.commands.generate_probe.compute_batch_dimer_dg", side_effect=lambda pairs: [0.0] * len(pairs))
     def test_avoids_n_probes(self, mock_dg):
         """Probes with N should be excluded."""
         target_seqs = ["ATCGNNNATCGATCGATCGATCGATCGATCG"]
@@ -43,7 +43,7 @@ class TestGenerateProbes:
         for seq in filtered:
             assert "N" not in seq
 
-    @patch("qprimer_designer.commands.generate_probe.compute_self_dimer_dg", return_value=0.0)
+    @patch("qprimer_designer.commands.generate_probe.compute_batch_dimer_dg", side_effect=lambda pairs: [0.0] * len(pairs))
     def test_avoid_5prime_g(self, mock_dg):
         """Probes starting with G should be excluded when avoid_5prime_G=True."""
         target_seqs = ["ATCGATCGATCGATCGATCGATCGATCGATCGATCGATCG"]
@@ -59,7 +59,7 @@ class TestGenerateProbes:
         for seq in filtered:
             assert seq[0] != 'G'
 
-    @patch("qprimer_designer.commands.generate_probe.compute_self_dimer_dg", return_value=0.0)
+    @patch("qprimer_designer.commands.generate_probe.compute_batch_dimer_dg", side_effect=lambda pairs: [0.0] * len(pairs))
     def test_homopolymer_filter(self, mock_dg):
         """Probes with long homopolymer runs should be excluded."""
         # Create a target with a long run of A's
@@ -78,7 +78,7 @@ class TestGenerateProbes:
         for seq in filtered:
             assert not has_homopolymer(seq, 3)
 
-    @patch("qprimer_designer.commands.generate_probe.compute_self_dimer_dg", return_value=0.0)
+    @patch("qprimer_designer.commands.generate_probe.compute_batch_dimer_dg", side_effect=lambda pairs: [0.0] * len(pairs))
     def test_max_num_subsampling(self, mock_dg):
         """Output should be limited to max_num probes."""
         target_seqs = ["ATCGATCGATCGATCGATCGATCGATCGATCGATCGATCG"]
@@ -93,7 +93,7 @@ class TestGenerateProbes:
         )
         assert len(filtered) <= 5
 
-    @patch("qprimer_designer.commands.generate_probe.compute_self_dimer_dg", return_value=-100.0)
+    @patch("qprimer_designer.commands.generate_probe.compute_batch_dimer_dg", side_effect=lambda pairs: [-100.0] * len(pairs))
     def test_dg_filter(self, mock_dg):
         """Probes with dG below threshold should be excluded."""
         target_seqs = ["ATCGATCGATCGATCGATCGATCGATCGATCGATCGATCG"]
@@ -108,7 +108,7 @@ class TestGenerateProbes:
         )
         assert len(filtered) == 0
 
-    @patch("qprimer_designer.commands.generate_probe.compute_self_dimer_dg", return_value=0.0)
+    @patch("qprimer_designer.commands.generate_probe.compute_batch_dimer_dg", side_effect=lambda pairs: [0.0] * len(pairs))
     def test_features_populated(self, mock_dg):
         """Features dict should have Tm, GC, len, position, dG for each probe."""
         target_seqs = ["ATCGATCGATCGATCGATCGATCGATCGATCGATCGATCG"]

--- a/tests/test_params_extended.py
+++ b/tests/test_params_extended.py
@@ -136,7 +136,7 @@ class TestGetPrimerParams:
         }
         result = get_primer_params(params)
         assert result["max_num"] == 500
-        assert result["step"] == 3
+        assert result["step"] == 1  # always 1, TILING_STEP param removed
         assert result["min_pri_len"] == 18
         assert result["max_pri_len"] == 25
         assert result["min_amp_len"] == 100

--- a/tests/test_sequences_extended.py
+++ b/tests/test_sequences_extended.py
@@ -116,7 +116,7 @@ class TestSanitizeIupac:
         assert sanitize_iupac("RYSW") == "NNNN"
 
     def test_lowercase_ambiguity(self):
-        assert sanitize_iupac("arcg") == "aNcg"
+        assert sanitize_iupac("arcg") == "ANCG"
 
     def test_preserves_n(self):
         assert sanitize_iupac("ANCG") == "ANCG"

--- a/workflows/Snakefile.template
+++ b/workflows/Snakefile.template
@@ -78,11 +78,35 @@ if os.path.isdir(TARGET_DIR):
             os.rename(_fpath, _new_path)
 
 # Generate RUN_ID if not set
-if not RUN_ID:
+_auto_id = not RUN_ID
+if _auto_id:
     RUN_ID = datetime.now().strftime("%Y%m%d_%H%M%S")
 
-FINAL_DIR = f"final/{RUN_ID}"
-EVAL_DIR = f"evaluate/{RUN_ID}"
+# Avoid overwriting existing runs: only when auto-generated
+# (Snakemake subprocess workers re-parse this file, so a hardcoded
+#  RUN_ID must stay stable even after the directory is created.)
+if _auto_id:
+    _base_id = RUN_ID
+    _suffix = 2
+    while os.path.exists(f"runs/{RUN_ID}"):
+        RUN_ID = f"{_base_id}_{_suffix}"
+        _suffix += 1
+
+RUN_DIR = f"runs/{RUN_ID}"
+
+# Rule priority: resolve ambiguities from flat directory structure.
+# prepare_pset_fasta has a greedy {filename} wildcard; quick_design and
+# generate_primers both produce _init.fa/_init.feat (checkpoint picks one).
+ruleorder: quick_design_on_target > generate_primers > prepare_pset_fasta
+ruleorder: quick_design_on_target > evaluate
+ruleorder: quick_design_on_target > prepare_features
+ruleorder: generate_primers > prepare_features
+ruleorder: filter_primer_list > prepare_pset_fasta
+ruleorder: generate_probes > prepare_pset_fasta
+ruleorder: resolve_target_seq > prepare_pset_fasta
+ruleorder: pick_representative_seqs > prepare_pset_fasta
+ruleorder: filter_primer_list > extract_probe_from_pset > prepare_pset_fasta
+ruleorder: quick_design_on_target > parse_probe_mapping
 
 # Probe mode
 PROBE_MODE = bool(int(config.get("probe", 0)))
@@ -95,21 +119,22 @@ else:
     TARGETS_PATTERN = "|".join(TARGETS) if TARGETS else ".*"
     ALL_TARGETS_PATTERN = "|".join(ALL_TARGETS) if ALL_TARGETS else ".*"
 
-# Read PROBE_MAX_MISMATCHES from params (used for post-alignment filtering)
-def get_probe_max_mismatches():
-    """Read PROBE_MAX_MISMATCHES from params file."""
+# Read probe filtering params (used for post-alignment filtering)
+def _read_probe_param(name, default):
+    """Read a probe parameter from params file."""
     if not os.path.exists(PARAMS):
-        return 2  # Default
+        return default
     with open(PARAMS) as f:
         for line in f:
-            if line.strip().startswith('PROBE_MAX_MISMATCHES'):
+            if line.strip().startswith(name):
                 try:
                     return int(line.split('=')[1].strip().split('#')[0].strip())
                 except:
-                    return 2
-    return 2
+                    return default
+    return default
 
-PROBE_MAX_MISMATCHES = get_probe_max_mismatches()
+PROBE_MAX_MISMATCHES = _read_probe_param('PROBE_MAX_MISMATCHES', 2)
+PROBE_MAX_INDELS = _read_probe_param('PROBE_MAX_INDELS', 0)
 
 ############################################
 # Helper functions
@@ -197,26 +222,62 @@ if EVALUATE:
         PSET_NAME = f"eval_f_{f_tag}_r_{r_tag}"
 
 ############################################
+# Route targets: quick vs standard (computed at parse time)
+############################################
+
+# Quick mode: multi-sequence targets in design mode (including probe mode)
+# Standard mode: single-sequence targets or evaluate mode
+if not EVALUATE:
+    QUICK_TARGETS = [t for t in TARGETS if count_seqs(t) > 1]
+    STANDARD_TARGETS = [t for t in TARGETS if count_seqs(t) <= 1]
+else:
+    QUICK_TARGETS = []
+    STANDARD_TARGETS = list(TARGETS)
+
+# Representative targets: standard targets with >5 sequences (need MSA + selection)
+REPR_TARGETS = set(t for t in STANDARD_TARGETS if count_seqs(t) > 5)
+
+QUICK_PATTERN = "|".join(QUICK_TARGETS) if QUICK_TARGETS else "NEVER_MATCH_QD"
+STANDARD_PATTERN = "|".join(STANDARD_TARGETS) if STANDARD_TARGETS else "NEVER_MATCH_SD"
+QUICK_SET = set(QUICK_TARGETS)
+
+def _eval_path(virus):
+    """Return eval file path inside _{virus}/ subdir."""
+    return f"{RUN_DIR}/_{virus}/{virus}.{virus}.eval"
+
+def _select_init_feat(wc):
+    """Select init features file."""
+    if EVALUATE:
+        return f"{RUN_DIR}/{wc.virus}.feat"
+    return f"{RUN_DIR}/{wc.virus}_init.feat"
+
+def _select_prev_eval(wc):
+    """Select previous eval file for off-target prepare_input."""
+    if wc.virus == wc.target or EVALUATE:
+        return []
+    return [_eval_path(wc.virus)]
+
+############################################
 # Final targets
 ############################################
 
 if EVALUATE:
     rule all:
         input:
-            f"outputs/{PSET_NAME}.{PRIMARY_TARGET}.eval.rescue_done"
+            f"{RUN_DIR}/_{PRIMARY_TARGET}/{PSET_NAME}.{PRIMARY_TARGET}.eval.rescue_done"
 
 elif MULTIPLEX:
     MULTIPLEX_STEM = "_".join(sorted(PANEL))
 
     rule all:
         input:
-            f"{FINAL_DIR}/{MULTIPLEX_STEM}.csv"
+            f"{RUN_DIR}/{MULTIPLEX_STEM}_final.csv"
 
     rule select_best_multiplex:
         input:
-            csvs=expand(f"{FINAL_DIR}/{{on}}.csv", on=PANEL)
+            csvs=expand(f"{RUN_DIR}/{{on}}_final.csv", on=PANEL)
         output:
-            f"{FINAL_DIR}/{MULTIPLEX_STEM}.csv"
+            f"{RUN_DIR}/{MULTIPLEX_STEM}_final.csv"
         params:
             params_arg=f"--params '{PARAMS}'" if PROBE_MODE else ""
         shell:
@@ -228,22 +289,22 @@ elif MULTIPLEX:
         wildcard_constraints:
             on=TARGETS_PATTERN
         input:
-            eval_on="outputs/{on}.{on}.eval",
-            eval_off=lambda wc: [f"outputs/{wc.on}.{t}.eval" for t in off_targets(wc.on)],
-            fa="primer_seqs/{on}_filt.fa",
+            eval_on=lambda wc: _eval_path(wc.on),
+            eval_off=lambda wc: [f"{RUN_DIR}/_{t}/{wc.on}.{t}.eval" for t in off_targets(wc.on)],
+            fa=f"{RUN_DIR}/{{on}}_filt.fa",
             ref="target_seqs/original/{on}.fa",
             probe_mapping_on=lambda wc: (
-                f"alignments/{wc.on}.{wc.on}.probe.csv" if PROBE_MODE else []
+                f"{RUN_DIR}/_{wc.on}/{wc.on}.{wc.on}.probe.csv" if PROBE_MODE else []
             ),
             probe_mapping_off=lambda wc: (
-                [f"alignments/{wc.on}.{t}.probe.csv" for t in off_targets(wc.on)]
+                [f"{RUN_DIR}/_{t}/{wc.on}.{t}.probe.csv" for t in off_targets(wc.on)]
                 if PROBE_MODE else []
             ),
             probe_seqs=lambda wc: (
-                f"primer_seqs/{wc.on}_filt_probes.fa" if PROBE_MODE else []
+                f"{RUN_DIR}/{wc.on}_filt_probes.fa" if PROBE_MODE else []
             )
         output:
-            f"{FINAL_DIR}/{{on}}.csv"
+            f"{RUN_DIR}/{{on}}_final.csv"
         params:
             off_arg=lambda wc, input: "--off " + " ".join(shlex.quote(str(f)) for f in input.eval_off) if input.eval_off else "",
             probe_args=lambda wc, input: (
@@ -262,28 +323,28 @@ elif MULTIPLEX:
 else:
     rule all:
         input:
-            expand(f"{FINAL_DIR}/{{virus}}.csv", virus=TARGETS)
+            expand(f"{RUN_DIR}/{{virus}}_final.csv", virus=TARGETS)
 
     rule build_final_output:
         wildcard_constraints:
             virus=TARGETS_PATTERN
         input:
-            eval_on="outputs/{virus}.{virus}.eval",
-            eval_off=lambda wc: [f"outputs/{wc.virus}.{t}.eval" for t in OFF_TARGETS],
-            fa="primer_seqs/{virus}_filt.fa",
+            eval_on=lambda wc: _eval_path(wc.virus),
+            eval_off=lambda wc: [f"{RUN_DIR}/_{t}/{wc.virus}.{t}.eval" for t in OFF_TARGETS],
+            fa=f"{RUN_DIR}/{{virus}}_filt.fa",
             ref="target_seqs/original/{virus}.fa",
             probe_mapping_on=lambda wc: (
-                f"alignments/{wc.virus}.{wc.virus}.probe.csv" if PROBE_MODE else []
+                f"{RUN_DIR}/_{wc.virus}/{wc.virus}.{wc.virus}.probe.csv" if PROBE_MODE else []
             ),
             probe_mapping_off=lambda wc: (
-                [f"alignments/{wc.virus}.{t}.probe.csv" for t in OFF_TARGETS]
+                [f"{RUN_DIR}/_{t}/{wc.virus}.{t}.probe.csv" for t in OFF_TARGETS]
                 if PROBE_MODE else []
             ),
             probe_seqs=lambda wc: (
-                f"primer_seqs/{wc.virus}_filt_probes.fa" if PROBE_MODE else []
+                f"{RUN_DIR}/{wc.virus}_filt_probes.fa" if PROBE_MODE else []
             )
         output:
-            f"{FINAL_DIR}/{{virus}}.csv"
+            f"{RUN_DIR}/{{virus}}_final.csv"
         params:
             off_arg=lambda wc, input: "--off " + " ".join(shlex.quote(str(f)) for f in input.eval_off) if input.eval_off else "",
             probe_args=lambda wc, input: (
@@ -303,25 +364,6 @@ else:
 # MSA + representative selection
 ############################################
 
-checkpoint choose_target_seq:
-    input:
-        "target_seqs/original/{virus}.fa"
-    output:
-        "target_seqs/choice/{virus}.txt"
-    params:
-        max_seqs_to_bypass_msa=5
-    run:
-        n = count_seqs(wildcards.virus)
-        choice = (
-            "original"
-            if n <= params.max_seqs_to_bypass_msa
-            else "representative"
-        )
-
-        os.makedirs(os.path.dirname(output[0]), exist_ok=True)
-        with open(output[0], "w") as out:
-            out.write(choice + "\n")
-
 
 rule make_MSA:
     wildcard_constraints:
@@ -331,9 +373,9 @@ rule make_MSA:
     output:
         "target_seqs/msa/{virus}.aln"
     threads:
-        min(2, MAX_CORES)
+        min(8, MAX_CORES)
     shell:
-        "mafft --auto --quiet --thread {threads} '{input}' > '{output}'"
+        "mafft --retree 1 --6merpair --thread {threads} '{input}' > '{output}' 2>/dev/null"
 
 
 rule pick_representative_seqs:
@@ -342,8 +384,8 @@ rule pick_representative_seqs:
     input:
         "target_seqs/msa/{virus}.aln"
     output:
-        fa="target_seqs/representative/{virus}.fa",
-        probe_regions="target_seqs/representative/{virus}_probe_regions.tsv"
+        fa=f"{RUN_DIR}/{{virus}}_repr.fa",
+        probe_regions=f"{RUN_DIR}/{{virus}}_repr_probe_regions.tsv"
     shell:
         "qprimer pick-representatives "
         "--in '{input}' --out '{output.fa}' "
@@ -351,30 +393,22 @@ rule pick_representative_seqs:
         "--probe-regions '{output.probe_regions}'"
 
 def selected_source_fa(wc):
-    # Ensure the checkpoint has run and we can read its output
-    ckpt = checkpoints.choose_target_seq.get(virus=wc.virus)
-    choice_file = ckpt.output[0]
-    choice = open(choice_file).read().strip()
-    if choice == "representative":
-        return f"target_seqs/representative/{wc.virus}.fa"
-    else:
-        return f"target_seqs/original/{wc.virus}.fa"
+    if wc.virus in REPR_TARGETS:
+        return f"{RUN_DIR}/{wc.virus}_repr.fa"
+    return f"target_seqs/original/{wc.virus}.fa"
 
 def selected_probe_regions(wc):
-    """Return probe regions file if representative path was chosen."""
-    ckpt = checkpoints.choose_target_seq.get(virus=wc.virus)
-    choice = open(ckpt.output[0]).read().strip()
-    if choice == "representative":
-        return f"target_seqs/representative/{wc.virus}_probe_regions.tsv"
+    if wc.virus in REPR_TARGETS:
+        return f"{RUN_DIR}/{wc.virus}_repr_probe_regions.tsv"
     return []
 
 rule resolve_target_seq:
     wildcard_constraints:
-        virus=TARGETS_PATTERN
+        virus=STANDARD_PATTERN
     input:
-        choice=lambda wc: checkpoints.choose_target_seq.get(virus=wc.virus).output[0], src=selected_source_fa
+        src=selected_source_fa
     output:
-        "target_seqs/selected/{virus}.fa"
+        f"{RUN_DIR}/{{virus}}_selected.fa"
     run:
         os.makedirs(os.path.dirname(output[0]), exist_ok=True)
         shell("cp '{input.src}' '{output}'")
@@ -385,12 +419,12 @@ rule resolve_target_seq:
 
 rule generate_primers:
     wildcard_constraints:
-        virus=TARGETS_PATTERN
+        virus=STANDARD_PATTERN
     input:
-        "target_seqs/selected/{virus}.fa"
+        f"{RUN_DIR}/{{virus}}_selected.fa"
     output:
-        fasta="primer_seqs/{virus}_init.fa",
-        features="primer_seqs/{virus}_init.feat"
+        fasta=f"{RUN_DIR}/{{virus}}_init.fa",
+        features=f"{RUN_DIR}/{{virus}}_init.feat"
     shell:
         "qprimer generate "
         "--in '{input}' --out '{output.fasta}' "
@@ -400,13 +434,13 @@ rule generate_primers:
 rule generate_probes:
     """Generate probe candidates from target sequences."""
     wildcard_constraints:
-        virus=TARGETS_PATTERN
+        virus=STANDARD_PATTERN
     input:
-        seqs="target_seqs/selected/{virus}.fa",
+        seqs=f"{RUN_DIR}/{{virus}}_selected.fa",
         regions=selected_probe_regions
     output:
-        fasta="primer_seqs/{virus}_probe.fa",
-        features="primer_seqs/{virus}_probe.feat"
+        fasta=f"{RUN_DIR}/{{virus}}_probe.fa",
+        features=f"{RUN_DIR}/{{virus}}_probe.feat"
     run:
         regions_arg = f"--conserved-regions '{input.regions}'" if input.regions else ""
         shell(
@@ -418,6 +452,59 @@ rule generate_probes:
 
 
 ############################################
+# Quick design mode (multi-sequence targets)
+############################################
+
+if PROBE_MODE:
+    rule quick_design_on_target:
+        """Run quick-design with probe-first mode for on-target sensitivity."""
+        wildcard_constraints:
+            virus=QUICK_PATTERN
+        input:
+            target="target_seqs/original/{virus}.fa",
+            msa="target_seqs/msa/{virus}.aln"
+        output:
+            eval=f"{RUN_DIR}/_{{virus}}/{{virus}}.{{virus}}.eval",
+            fasta=f"{RUN_DIR}/{{virus}}_init.fa",
+            features=f"{RUN_DIR}/{{virus}}_init.feat",
+            probe_fa=f"{RUN_DIR}/{{virus}}_probe.fa",
+            probe_feat=f"{RUN_DIR}/{{virus}}_probe.feat",
+            probe_csv=f"{RUN_DIR}/_{{virus}}/{{virus}}.{{virus}}.probe.csv"
+        threads:
+            min(4, MAX_CORES)
+        shell:
+            "qprimer quick-design "
+            "--target '{input.target}' --msa '{input.msa}' "
+            "--out '{output.eval}' "
+            "--init-fa '{output.fasta}' --init-feat '{output.features}' "
+            "--probe-mode --probe-fa '{output.probe_fa}' --probe-feat '{output.probe_feat}' "
+            "--probe-csv '{output.probe_csv}' "
+            "--params '{PARAMS}' --name '{wildcards.virus}' "
+            "--threads {threads}"
+else:
+    rule quick_design_on_target:
+        """Run quick-design for on-target sensitivity when n > 1 sequences."""
+        wildcard_constraints:
+            virus=QUICK_PATTERN
+        input:
+            target="target_seqs/original/{virus}.fa",
+            msa="target_seqs/msa/{virus}.aln"
+        output:
+            eval=f"{RUN_DIR}/_{{virus}}/{{virus}}.{{virus}}.eval",
+            fasta=f"{RUN_DIR}/{{virus}}_init.fa",
+            features=f"{RUN_DIR}/{{virus}}_init.feat"
+        threads:
+            min(4, MAX_CORES)
+        shell:
+            "qprimer quick-design "
+            "--target '{input.target}' --msa '{input.msa}' "
+            "--out '{output.eval}' "
+            "--init-fa '{output.fasta}' --init-feat '{output.features}' "
+            "--params '{PARAMS}' --name '{wildcards.virus}' "
+            "--threads {threads}"
+
+
+############################################
 # Evaluation of user-defined primers
 ############################################
 
@@ -425,7 +512,7 @@ rule prepare_pset_fasta:
     wildcard_constraints:
         filename="[^./]+"
     output:
-        fasta="evaluate/{filename}.fa"
+        fasta=f"{RUN_DIR}/{{filename}}.fa"
     run:
         out = Path(output.fasta)
         out.parent.mkdir(parents=True, exist_ok=True)
@@ -436,13 +523,13 @@ rule prepare_pset_fasta:
             shutil.copyfile(src, out)
 
         # case 2: direct for / rev → generate
-        # The reverse primer must be stored as RC to match the convention
-        # used by the 'generate' command (tiled from the RC of the target).
+        # Store the reverse primer as-is (5'→3').  The user supplies it in
+        # the same convention the 'generate' command produces: tiled from
+        # the RC strand, so bowtie2 will align it with orientation 16,
+        # which is what prepare_input expects for reverse primers.
         else:
             for_seq = config["for"]
             rev_seq = config["rev"]
-            comp = str.maketrans("ACGTacgt", "TGCAtgca")
-            rev_seq_rc = rev_seq.translate(comp)[::-1]
 
             # Use a readable primer pair ID from the sequences
             f_tag = (for_seq[:5] + for_seq[-5:]).upper() if len(for_seq) >= 10 else for_seq.upper()
@@ -450,7 +537,7 @@ rule prepare_pset_fasta:
             pair_id = f"f_{f_tag}_r_{r_tag}"
 
             with open(out, "w") as f:
-                f.write(f">{pair_id}_for\n{for_seq}\n>{pair_id}_rev\n{rev_seq_rc}\n")
+                f.write(f">{pair_id}_for\n{for_seq}\n>{pair_id}_rev\n{rev_seq}\n")
                 # Optionally add probe sequence
                 pro_seq = config.get("pro")
                 if pro_seq:
@@ -462,9 +549,9 @@ rule prepare_features:
     wildcard_constraints:
         filename="[^./]+"
     input:
-        fa="evaluate/{filename}.fa"
+        fa=f"{RUN_DIR}/{{filename}}.fa"
     output:
-        feat="evaluate/{filename}.feat"
+        feat=f"{RUN_DIR}/{{filename}}.feat"
     shell:
         "qprimer prepare-features "
         "--fa '{input.fa}' "
@@ -475,9 +562,9 @@ rule extract_probe_from_pset:
     wildcard_constraints:
         filename="[^./]+"
     input:
-        fasta="evaluate/{filename}.fa"
+        fasta=f"{RUN_DIR}/{{filename}}.fa"
     output:
-        probe_fa="evaluate/probes/{filename}.fa"
+        probe_fa=f"{RUN_DIR}/{{filename}}_probes.fa"
     run:
         from Bio import SeqIO
         probes = [r for r in SeqIO.parse(input.fasta, "fasta") if r.id.endswith("_pro")]
@@ -498,33 +585,34 @@ rule evaluate_pset:
     wildcard_constraints:
         filename="[^./]+"
     input:
-        eval_on=f"outputs/{{filename}}.{PRIMARY_TARGET}.eval",
-        eval_off=lambda wc: [f"outputs/{wc.filename}.{t}.eval" for t in OFF_TARGETS],
-        fasta="evaluate/{filename}.fa",
+        eval_on=f"{RUN_DIR}/_{PRIMARY_TARGET}/{{filename}}.{PRIMARY_TARGET}.eval",
+        eval_off=lambda wc: [f"{RUN_DIR}/_{t}/{wc.filename}.{t}.eval" for t in OFF_TARGETS],
+        fasta=f"{RUN_DIR}/{{filename}}.fa",
         off_refs=lambda wc: [f"target_seqs/original/{t}.fa" for t in OFF_TARGETS],
-        probe_mapping_on=lambda wc: (
-            f"alignments/{wc.filename}.{PRIMARY_TARGET}.probe.csv"
+        mapped_on=lambda wc: (
+            f"{RUN_DIR}/_{PRIMARY_TARGET}/{wc.filename}.{PRIMARY_TARGET}.mapped"
             if EVAL_HAS_PROBE else []
         ),
-        probe_mapping_off=lambda wc: (
-            [f"alignments/{wc.filename}.{t}.probe.csv" for t in OFF_TARGETS]
+        mapped_off=lambda wc: (
+            [f"{RUN_DIR}/_{t}/{wc.filename}.{t}.mapped" for t in OFF_TARGETS]
             if EVAL_HAS_PROBE else []
         ),
         probe_fa=lambda wc: (
-            f"evaluate/probes/{wc.filename}.fa"
+            f"{RUN_DIR}/{wc.filename}_probes.fa"
             if EVAL_HAS_PROBE else []
         )
     output:
-        directory(f"{EVAL_DIR}/{{filename}}")
+        directory(f"{RUN_DIR}/{{filename}}")
     params:
-        ids=lambda wc: " ".join(shlex.quote(i) for i in check_ids(f"evaluate/{wc.filename}.fa")),
+        ids=lambda wc: " ".join(shlex.quote(i) for i in check_ids(f"{RUN_DIR}/{wc.filename}.fa")),
         off_arg=lambda wc, input: "--off " + " ".join(shlex.quote(str(f)) for f in input.eval_off) if input.eval_off else "",
         off_ref_arg=lambda wc, input: "--off-ref " + " ".join(shlex.quote(str(f)) for f in input.off_refs) if input.off_refs else "",
         probe_args=lambda wc, input: (
-            f"--probe-mapping-on {shlex.quote(str(input.probe_mapping_on))} "
-            f"--probe-mapping-off {' '.join(shlex.quote(str(f)) for f in input.probe_mapping_off)} "
+            f"--mapped-on {shlex.quote(str(input.mapped_on))} "
+            f"--mapped-off {' '.join(shlex.quote(str(f)) for f in input.mapped_off)} "
             f"--probe-seqs {shlex.quote(str(input.probe_fa))} "
-            f"--probe-max-mismatches {PROBE_MAX_MISMATCHES}"
+            f"--probe-max-mismatches {PROBE_MAX_MISMATCHES} "
+            f"--probe-max-indels {PROBE_MAX_INDELS}"
             if EVAL_HAS_PROBE else ""
         )
     shell:
@@ -548,11 +636,11 @@ rule build_index:
     input:
         "target_seqs/original/{target}.fa"
     output:
-        "bt2_index/{target}.1.bt2"
+        f"{RUN_DIR}/_intermediate/{{target}}.1.bt2"
     threads:
         lambda wc: min(4, MAX_CORES) if count_seqs(wc.target) > 1000 else 1
     shell:
-        "bowtie2-build --threads {threads} '{input}' 'bt2_index/{wildcards.target}'"
+        "bowtie2-build --threads {threads} '{input}' '" + RUN_DIR + "/_intermediate/{wildcards.target}'"
 
 
 rule align:
@@ -561,20 +649,20 @@ rule align:
         target=ALL_TARGETS_PATTERN
     input:
         fasta=lambda wc: (
-            f"evaluate/{wc.virus}.fa" if EVALUATE
-            else (f"primer_seqs/{wc.virus}_init.fa"
+            f"{RUN_DIR}/{wc.virus}.fa" if EVALUATE
+            else (f"{RUN_DIR}/{wc.virus}_init.fa"
                     if wc.virus == wc.target
-                    else f"primer_seqs/{wc.virus}_filt.fa")
+                    else f"{RUN_DIR}/{wc.virus}_filt.fa")
         ),
-        index="bt2_index/{target}.1.bt2"
+        index=f"{RUN_DIR}/_intermediate/{{target}}.1.bt2"
     output:
-        temp("alignments/{virus}.{target}.sam")
+        temp(f"{RUN_DIR}/_{{target}}/{{virus}}.{{target}}.sam")
     threads:
         min(2, MAX_CORES)
     params:
-        reference=lambda wc: f"bt2_index/{wc.target}",
+        reference=lambda wc: f"{RUN_DIR}/_intermediate/{wc.target}",
         multiMap=lambda wc: min(count_seqs(wc.target) * 2, 50000),
-        mapOption="--mp 2,2 --np 2 --rdg 4,4 --rfg 4,4 -L 8 -N 1 --score-min L,-0.6,-0.6"
+        mapOption="--mp 2,2 --np 2 --rdg 4,4 --rfg 4,4 -L 6 -N 1 --score-min L,-0.6,-0.6"
     shell:
         "bowtie2 -x '{params.reference}' -U '{input.fasta}' -f "
         "-p {threads} -k {params.multiMap} {params.mapOption} "
@@ -588,20 +676,20 @@ rule align_probes:
         target=ALL_TARGETS_PATTERN
     input:
         fasta=lambda wc: (
-            f"evaluate/probes/{wc.virus}.fa" if EVALUATE
-            else (f"primer_seqs/{wc.virus}_probe.fa"
+            f"{RUN_DIR}/{wc.virus}_probes.fa" if EVALUATE
+            else (f"{RUN_DIR}/{wc.virus}_probe.fa"
                     if wc.virus == wc.target
-                    else f"primer_seqs/{wc.virus}_filt_probes.fa")
+                    else f"{RUN_DIR}/{wc.virus}_filt_probes.fa")
         ),
-        index="bt2_index/{target}.1.bt2"
+        index=f"{RUN_DIR}/_intermediate/{{target}}.1.bt2"
     output:
-        temp("alignments/{virus}.{target}.probe.sam")
+        temp(f"{RUN_DIR}/_{{target}}/{{virus}}.{{target}}.probe.sam")
     threads:
         min(2, MAX_CORES)
     params:
-        reference=lambda wc: f"bt2_index/{wc.target}",
+        reference=lambda wc: f"{RUN_DIR}/_intermediate/{wc.target}",
         multiMap=lambda wc: min(count_seqs(wc.target) * 2, 50000),
-        mapOption="--mp 3,3 --np 2 --rdg 6,4 --rfg 6,4 -L 8 -N 1 --score-min L,-0.6,-0.6"
+        mapOption="--mp 3,3 --np 2 --rdg 6,4 --rfg 6,4 -L 6 -N 1 --score-min L,-0.6,-0.6"
     shell:
         "bowtie2 -x '{params.reference}' -U '{input.fasta}' -f "
         "-p {threads} -k {params.multiMap} {params.mapOption} "
@@ -614,9 +702,9 @@ rule parse_probe_mapping:
         virus="[^./]+",
         target=ALL_TARGETS_PATTERN
     input:
-        sam="alignments/{virus}.{target}.probe.sam"
+        sam=f"{RUN_DIR}/_{{target}}/{{virus}}.{{target}}.probe.sam"
     output:
-        "alignments/{virus}.{target}.probe.csv"
+        f"{RUN_DIR}/_{{target}}/{{virus}}.{{target}}.probe.csv"
     shell:
         "qprimer parse-probe-mapping "
         "--sam '{input.sam}' --out '{output}'"
@@ -627,20 +715,26 @@ rule parse_probe_mapping:
 ############################################
 
 rule parse_map:
+    wildcard_constraints:
+        virus="[^./]+",
+        target=ALL_TARGETS_PATTERN
     input:
-        "alignments/{filename}.sam"
+        f"{RUN_DIR}/_{{target}}/{{virus}}.{{target}}.sam"
     output:
-        temp("alignments/{filename}.parsed")
+        temp(f"{RUN_DIR}/_{{target}}/{{virus}}.{{target}}.parsed")
     shell:
         "sam2pairwise < '{input}' > '{output}'"
 
 
 rule process_map:
+    wildcard_constraints:
+        virus="[^./]+",
+        target=ALL_TARGETS_PATTERN
     input:
-        sam="alignments/{filename}.sam",
-        parsed="alignments/{filename}.parsed"
+        sam=f"{RUN_DIR}/_{{target}}/{{virus}}.{{target}}.sam",
+        parsed=f"{RUN_DIR}/_{{target}}/{{virus}}.{{target}}.parsed"
     output:
-        temp("alignments/{filename}.mapped.temp")
+        temp(f"{RUN_DIR}/_{{target}}/{{virus}}.{{target}}.mapped.temp")
     run:
         pseqs = input.parsed + ".pseq"
         tseqs = input.parsed + ".tseq"
@@ -662,9 +756,9 @@ rule check_coverage:
         virus="[^./]+",
         target=ALL_TARGETS_PATTERN
     input:
-        mapped="alignments/{virus}.{target}.mapped.temp"
+        mapped=f"{RUN_DIR}/_{{target}}/{{virus}}.{{target}}.mapped.temp"
     output:
-        "alignments/{virus}.{target}.mapped"
+        f"{RUN_DIR}/_{{target}}/{{virus}}.{{target}}.mapped"
     params:
         min_cov=lambda wc: int(count_seqs(wc.target) * 0.95)
     run:
@@ -698,23 +792,17 @@ rule prepare_input:
         virus="[^./]+",
         target=ALL_TARGETS_PATTERN
     input:
-        mapped="alignments/{virus}.{target}.mapped",
-        prev=lambda wc: (
-            [f"outputs/{wc.virus}.{wc.virus}.eval"]
-            if wc.virus != wc.target and not EVALUATE else []
-        ),
+        mapped=f"{RUN_DIR}/_{{target}}/{{virus}}.{{target}}.mapped",
+        prev=_select_prev_eval,
         ref="target_seqs/original/{target}.fa",
-        features=lambda wc: (
-            "evaluate/{virus}.feat" if EVALUATE
-            else "primer_seqs/{virus}_init.feat"
-        )
+        features=_select_init_feat
     output:
-        "inputs/{virus}.{target}.input"
+        f"{RUN_DIR}/_{{target}}/{{virus}}.{{target}}.input"
     params:
         ref_type=lambda wc: "on" if (wc.virus == wc.target or (EVALUATE and wc.target == PRIMARY_TARGET)) else "off",
-        prev_arg=lambda wc: (
-            f"--prev 'outputs/{wc.virus}.{wc.virus}.eval'"
-            if wc.virus != wc.target and not EVALUATE else ""
+        prev_arg=lambda wc, input: (
+            f"--prev '{input.prev[0]}'"
+            if input.prev else ""
         )
     shell:
         "qprimer prepare-input "
@@ -728,10 +816,10 @@ rule evaluate:
         virus="[^./]+",
         target=ALL_TARGETS_PATTERN
     input:
-        inp="inputs/{virus}.{target}.input",
+        inp=f"{RUN_DIR}/_{{target}}/{{virus}}.{{target}}.input",
         ref="target_seqs/original/{target}.fa"
     output:
-        "outputs/{virus}.{target}.eval"
+        f"{RUN_DIR}/_{{target}}/{{virus}}.{{target}}.eval"
     threads:
         min(2, MAX_CORES)
     resources:
@@ -750,26 +838,26 @@ rule rescue_evaluate:
         virus="[^./]+",
         target=ALL_TARGETS_PATTERN
     input:
-        eval="outputs/{virus}.{target}.eval",
+        eval=f"{RUN_DIR}/_{{target}}/{{virus}}.{{target}}.eval",
         report_dir=lambda wc: (
-            f"{EVAL_DIR}/{wc.virus}" if EVALUATE
+            f"{RUN_DIR}/{wc.virus}" if EVALUATE
             else []
         ),
         fasta=lambda wc: (
-            f"evaluate/{wc.virus}.fa" if EVALUATE
-            else f"primer_seqs/{wc.virus}_init.fa"
+            f"{RUN_DIR}/{wc.virus}.fa" if EVALUATE
+            else f"{RUN_DIR}/{wc.virus}_init.fa"
         ),
         ref="target_seqs/original/{target}.fa",
         features=lambda wc: (
-            f"evaluate/{wc.virus}.feat" if EVALUATE
-            else f"primer_seqs/{wc.virus}_init.feat"
+            f"{RUN_DIR}/{wc.virus}.feat" if EVALUATE
+            else f"{RUN_DIR}/{wc.virus}_init.feat"
         )
     output:
-        touch("outputs/{virus}.{target}.eval.rescue_done")
+        touch(f"{RUN_DIR}/_{{target}}/{{virus}}.{{target}}.eval.rescue_done")
     params:
         ref_type=lambda wc: "on" if (wc.virus == wc.target or (EVALUATE and wc.target == PRIMARY_TARGET)) else "off",
         report_dir=lambda wc: (
-            f"{EVAL_DIR}/{wc.virus}" if EVALUATE
+            f"{RUN_DIR}/{wc.virus}" if EVALUATE
             else ""
         )
     threads:
@@ -783,32 +871,37 @@ rule rescue_evaluate:
         "--threads {threads}"
 
 
-rule filter_primer_list:
-    wildcard_constraints:
-        virus=TARGETS_PATTERN
-    input:
-        res="outputs/{virus}.{virus}.eval",
-        init="primer_seqs/{virus}_init.fa",
-        probe_mapping=lambda wc: (
-            f"alignments/{wc.virus}.{wc.virus}.probe.csv" if PROBE_MODE else []
-        ),
-        probe_seqs=lambda wc: (
-            f"primer_seqs/{wc.virus}_probe.fa" if PROBE_MODE else []
-        )
-    output:
-        fasta="primer_seqs/{virus}_filt.fa",
-        csv="primer_seqs/{virus}_filt.csv",
-        probe_csv="primer_seqs/{virus}_filt_probes.csv",
-        probe_fasta="primer_seqs/{virus}_filt_probes.fa"
-    params:
-        probe_args=lambda wc: (
-            f"--probe-mapping 'alignments/{wc.virus}.{wc.virus}.probe.csv' "
-            f"--probe-seqs 'primer_seqs/{wc.virus}_probe.fa' "
-            f"--probe-out 'primer_seqs/{wc.virus}_filt_probes.csv'"
-            if PROBE_MODE else ""
-        )
-    shell:
-        """
-        qprimer filter --init '{input.init}' --scores '{input.res}' --out '{output.fasta}' --params '{PARAMS}' {params.probe_args}
-        touch '{output.probe_csv}' '{output.probe_fasta}'
-        """
+if PROBE_MODE:
+    rule filter_primer_list:
+        wildcard_constraints:
+            virus=TARGETS_PATTERN
+        input:
+            res=lambda wc: _eval_path(wc.virus),
+            init=f"{RUN_DIR}/{{virus}}_init.fa",
+            probe_mapping=f"{RUN_DIR}/_{{virus}}/{{virus}}.{{virus}}.probe.csv",
+            probe_seqs=f"{RUN_DIR}/{{virus}}_probe.fa"
+        output:
+            fasta=f"{RUN_DIR}/{{virus}}_filt.fa",
+            csv=f"{RUN_DIR}/{{virus}}_filt.csv",
+            probe_csv=f"{RUN_DIR}/{{virus}}_filt_probes.csv",
+            probe_fasta=f"{RUN_DIR}/{{virus}}_filt_probes.fa"
+        shell:
+            "qprimer filter --init '{input.init}' --scores '{input.res}' "
+            "--out '{output.fasta}' --params '{PARAMS}' "
+            "--probe-mapping '{input.probe_mapping}' "
+            "--probe-seqs '{input.probe_seqs}' "
+            "--probe-out '{output.probe_csv}' && "
+            "touch '{output.probe_fasta}'"
+else:
+    rule filter_primer_list:
+        wildcard_constraints:
+            virus=TARGETS_PATTERN
+        input:
+            res=lambda wc: _eval_path(wc.virus),
+            init=f"{RUN_DIR}/{{virus}}_init.fa"
+        output:
+            fasta=f"{RUN_DIR}/{{virus}}_filt.fa",
+            csv=f"{RUN_DIR}/{{virus}}_filt.csv"
+        shell:
+            "qprimer filter --init '{input.init}' --scores '{input.res}' "
+            "--out '{output.fasta}' --params '{PARAMS}'"

--- a/workflows/params.txt.template
+++ b/workflows/params.txt.template
@@ -21,24 +21,28 @@ GC_MAX = 60
 DG_MIN = -6
 PRIMER_LEN_MIN = 19  # Primer length should be 18-24
 PRIMER_LEN_MAX = 21
-TILING_STEP = 5
 
 ## Parameters for probe generation
 PROBE_LEN_MIN = 24
-PROBE_LEN_MAX = 28
+PROBE_LEN_MAX = 26
 PROBE_TM_MIN = 65
-PROBE_TM_MAX = 70
+PROBE_TM_MAX = 75
 PROBE_GC_MAX = 60
 PROBE_DG_MIN = -8
-PROBE_HOMOPOLYMER_MAX = 3
-PROBE_AVOID_5PRIME_G = True
+PROBE_HOMOPOLYMER_MAX = 4
+PROBE_AVOID_5PRIME_G = False
 PROBE_CONSERVATION_THRESHOLD = 0.8  # Column conservation fraction for probe region selection
 
 ## Probe mode configuration (singleplex only)
 PROBE_MAX_MISMATCHES = 2  # Maximum mismatches for probe-to-target alignment
-PROBE_AMPLICON_BUFFER = 10  # Minimum distance (nt) from primer ends
+PROBE_MAX_INDELS = 0  # Maximum indels for probe-to-target alignment
+PROBE_AMPLICON_BUFFER = 15  # Minimum distance (nt) from primer ends
 MIN_PROBES_PER_PAIR = 1  # Minimum valid probes required per primer pair
 MAX_PROBES_PER_PAIR = 5  # Maximum number of probes to output per primer pair
+
+## Target thresholds for early stopping
+QUICK_COV_MIN = 1.0
+QUICK_ACT_MIN = 1.0
 
 ## Parameters in input preparation
 AMPLEN_MIN = 60


### PR DESCRIPTION
Enable quick design pipeline for probe mode targets. Implements probe-first flow: find conserved probe regions in MSA, generate probe candidates, find flanking primers, ML evaluate, and greedy probe-to-pair assignment in build_output. Includes Snakefile reorganization (off-target files in subdirectories), duplicate run directory fix, and filter pipeline changes to pass all valid probes through to final dedup.