### PR TITLE
Web delivery: serve the Streamlit GUI on Cloud Run (image split, terraform, per-run isolation)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -36,5 +36,8 @@ training/
 *.tar.gz
 *.zip
 
+# Terraform
+terraform/
+
 # Analysis artifacts
 CODEBASE_ANALYSIS.md

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,6 +12,8 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  GAR_REGION: us-central1
+  GAR_REGISTRY: us-central1-docker.pkg.dev/sabeti-adapt/qprimer-designer/qprimer-designer
 
 jobs:
   build-amd64:
@@ -20,13 +22,15 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write  # Workload Identity Federation
+      security-events: write  # Trivy SARIF upload
     outputs:
       digest: ${{ steps.build.outputs.digest }}
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
 
-      - name: Log in to Container Registry
+      - name: Log in to GHCR
         if: github.event_name == 'push'
         uses: docker/login-action@v3
         with:
@@ -34,11 +38,27 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Authenticate to Google Cloud
+        if: github.event_name == 'push'
+        id: gcp-auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_DEPLOY_SA }}
+
+      - name: Log in to Artifact Registry
+        if: github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.GAR_REGION }}-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.gcp-auth.outputs.access_token }}
+
       - name: Generate tag suffix
         id: tag
         run: |
-          # Sanitize ref_name: replace / with - for valid Docker tags
           echo "suffix=$(echo '${{ github.ref_name }}' | tr '/' '-')" >> $GITHUB_OUTPUT
+          echo "sha_short=$(echo '${{ github.sha }}' | head -c 12)" >> $GITHUB_OUTPUT
 
       - name: Build and push (amd64)
         id: build
@@ -47,13 +67,32 @@ jobs:
           context: .
           platforms: linux/amd64
           push: ${{ github.event_name == 'push' }}
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.suffix }}-amd64
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.suffix }}-amd64
+            ${{ github.event_name == 'push' && format('{0}:{1}-amd64', env.GAR_REGISTRY, steps.tag.outputs.suffix) || '' }}
+            ${{ github.event_name == 'push' && format('{0}:{1}', env.GAR_REGISTRY, steps.tag.outputs.sha_short) || '' }}
           provenance: false
           sbom: false
           cache-from: |
             type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-amd64
             type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main-amd64
           cache-to: ${{ github.event_name == 'push' && format('type=registry,ref={0}/{1}:buildcache-amd64,mode=max', env.REGISTRY, env.IMAGE_NAME) || '' }}
+
+      - name: Run Trivy vulnerability scanner
+        if: always() && steps.build.outcome == 'success'
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.suffix }}-amd64
+          format: sarif
+          output: trivy-results.sarif
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+
+      - name: Upload Trivy scan results
+        if: always() && steps.build.outcome == 'success'
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-results.sarif
 
   build-arm64:
     if: github.event_name != 'delete'
@@ -103,6 +142,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     steps:
       - uses: docker/login-action@v3
         with:
@@ -110,10 +150,23 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Authenticate to Google Cloud
+        id: gcp-auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_DEPLOY_SA }}
+
+      - name: Log in to Artifact Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.GAR_REGION }}-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.gcp-auth.outputs.access_token }}
+
       - name: Generate tag suffix
         id: tag
         run: |
-          # Sanitize ref_name: replace / with - for valid Docker tags
           echo "suffix=$(echo '${{ github.ref_name }}' | tr '/' '-')" >> $GITHUB_OUTPUT
 
       - name: Extract metadata
@@ -126,12 +179,11 @@ jobs:
             type=ref,event=tag
             type=raw,value=latest,enable={{is_default_branch}}
 
-      - name: Create and push manifest
+      - name: Create and push GHCR manifest
         env:
           TAGS: ${{ steps.meta.outputs.tags }}
           SUFFIX: ${{ steps.tag.outputs.suffix }}
         run: |
-          # Iterate over multi-line tags properly
           echo "$TAGS" | while IFS= read -r tag; do
             [ -z "$tag" ] && continue
             echo "Creating manifest for: $tag"
@@ -143,6 +195,87 @@ jobs:
               "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${SUFFIX}-amd64" \
               "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${SUFFIX}-arm64"
           done
+
+      - name: Tag latest in Artifact Registry
+        if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        run: |
+          gcloud artifacts docker tags add \
+            "${{ env.GAR_REGISTRY }}:${{ steps.tag.outputs.suffix }}-amd64" \
+            "${{ env.GAR_REGISTRY }}:latest"
+
+      - name: Tag version in Artifact Registry
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          gcloud artifacts docker tags add \
+            "${{ env.GAR_REGISTRY }}:${{ steps.tag.outputs.suffix }}-amd64" \
+            "${{ env.GAR_REGISTRY }}:${{ github.ref_name }}"
+
+  deploy:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    needs: [create-manifest]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_DEPLOY_SA }}
+
+      - name: Deploy to production
+        uses: google-github-actions/deploy-cloudrun@v2
+        with:
+          service: qprimer-designer
+          region: us-central1
+          image: ${{ env.GAR_REGISTRY }}:${{ github.ref_name }}
+
+  staging-deploy:
+    if: github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/')
+    needs: [build-amd64]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_DEPLOY_SA }}
+
+      - name: Generate revision tag
+        id: rev
+        run: |
+          # Cloud Run revision tags: lowercase, alphanumeric + hyphens, max 63 chars
+          TAG=$(echo '${{ github.ref_name }}' | tr '/' '-' | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g' | head -c 22)
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+
+      - name: Generate image tag
+        id: img
+        run: |
+          echo "sha_short=$(echo '${{ github.sha }}' | head -c 12)" >> $GITHUB_OUTPUT
+
+      - name: Deploy to staging
+        run: |
+          gcloud run deploy qprimer-designer-staging \
+            --image="${{ env.GAR_REGISTRY }}:${{ steps.img.outputs.sha_short }}" \
+            --region=us-central1 \
+            --tag="${{ steps.rev.outputs.tag }}" \
+            --no-traffic \
+            --allow-unauthenticated \
+            --memory=4Gi \
+            --cpu=4 \
+            --concurrency=80 \
+            --session-affinity \
+            --timeout=3600
+
+      - name: Show staging URL
+        run: |
+          echo "### Staging deployment" >> $GITHUB_STEP_SUMMARY
+          echo "Branch: \`${{ github.ref_name }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "URL: https://${{ steps.rev.outputs.tag }}---qprimer-designer-staging-$(gcloud run services describe qprimer-designer-staging --region=us-central1 --format='value(status.url)' | sed 's|https://||' | cut -d. -f1 | sed 's|qprimer-designer-staging-||').us-central1.run.app" >> $GITHUB_STEP_SUMMARY
 
   cleanup-untagged:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -76,7 +76,9 @@ jobs:
       # the image is only pushed then (Trivy pulls it by ref). Report-only.
       - name: Run Trivy vulnerability scanner (GHCR GPU image)
         if: github.event_name == 'push' && steps.build.outcome == 'success'
-        uses: aquasecurity/trivy-action@master
+        # Pinned to commit SHA, NOT a floating tag, because aquasecurity/trivy-action
+        # has pushed breaking changes under tags before (supply-chain hygiene).
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.suffix }}-amd64
           format: sarif
@@ -242,7 +244,7 @@ jobs:
       # Scan the public-facing GAR CPU image (Cloud Run). Report-only.
       - name: Run Trivy vulnerability scanner (GAR CPU image)
         if: always() && steps.build.outcome == 'success'
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0 — see note above
         with:
           image-ref: ${{ env.GAR_REGISTRY }}:${{ steps.tag.outputs.sha_short }}
           format: sarif

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,6 +9,11 @@ on:
   merge_group:
   delete:  # Trigger cleanup when branches are deleted
 
+# Collapse superseded runs on the same ref so a new push cancels the old build.
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
@@ -175,6 +180,9 @@ jobs:
         id: gcp-auth
         uses: google-github-actions/auth@v2
         with:
+          # access_token output is required by the docker/login-action below;
+          # the auth action only emits it when token_format is set explicitly.
+          token_format: 'access_token'
           workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
           service_account: ${{ secrets.GCP_DEPLOY_SA }}
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,6 +34,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      security-events: write  # Trivy SARIF upload
     outputs:
       digest: ${{ steps.build.outputs.digest }}
     steps:
@@ -70,6 +71,25 @@ jobs:
             type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-amd64
             type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main-amd64
           cache-to: ${{ github.event_name == 'push' && format('type=registry,ref={0}/{1}:buildcache-amd64,mode=max', env.REGISTRY, env.IMAGE_NAME) || '' }}
+
+      # Scan the GHCR GPU image (used by CLI/training/Terra). Only on push, since
+      # the image is only pushed then (Trivy pulls it by ref). Report-only.
+      - name: Run Trivy vulnerability scanner (GHCR GPU image)
+        if: github.event_name == 'push' && steps.build.outcome == 'success'
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.suffix }}-amd64
+          format: sarif
+          output: trivy-ghcr.sarif
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+
+      - name: Upload Trivy results (GHCR GPU image)
+        if: github.event_name == 'push' && steps.build.outcome == 'success'
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-ghcr.sarif
+          category: trivy-ghcr-gpu-amd64
 
   build-arm64:
     if: github.event_name != 'delete'
@@ -219,21 +239,23 @@ jobs:
           cache-from: type=registry,ref=${{ env.GAR_REGISTRY }}:buildcache-gar-cpu
           cache-to: type=registry,ref=${{ env.GAR_REGISTRY }}:buildcache-gar-cpu,mode=max
 
-      - name: Run Trivy vulnerability scanner
+      # Scan the public-facing GAR CPU image (Cloud Run). Report-only.
+      - name: Run Trivy vulnerability scanner (GAR CPU image)
         if: always() && steps.build.outcome == 'success'
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: ${{ env.GAR_REGISTRY }}:${{ steps.tag.outputs.sha_short }}
           format: sarif
-          output: trivy-results.sarif
+          output: trivy-gar.sarif
           severity: HIGH,CRITICAL
           ignore-unfixed: true
 
-      - name: Upload Trivy scan results
+      - name: Upload Trivy results (GAR CPU image)
         if: always() && steps.build.outcome == 'success'
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: trivy-results.sarif
+          sarif_file: trivy-gar.sarif
+          category: trivy-gar-cpu-amd64
 
   deploy:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,7 +13,14 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
   GAR_REGION: us-central1
+  GAR_PROJECT: sabeti-adapt
   GAR_REGISTRY: us-central1-docker.pkg.dev/sabeti-adapt/qprimer-designer/qprimer-designer
+
+# Two images are produced from one Dockerfile (see the TORCH_VARIANT build arg):
+#   GHCR  -> multi-arch (amd64+arm64), GPU-enabled. Used by training + the
+#            Terra/batch CLI. Built by build-amd64 + build-arm64 + create-manifest.
+#   GAR   -> amd64-only, CPU-only (slim). Runs the Streamlit web app on Cloud Run.
+#            Built by build-gar and deployed by staging-deploy / deploy.
 
 jobs:
   build-amd64:
@@ -22,8 +29,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      id-token: write  # Workload Identity Federation
-      security-events: write  # Trivy SARIF upload
     outputs:
       digest: ${{ steps.build.outputs.digest }}
     steps:
@@ -38,61 +43,28 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Authenticate to Google Cloud
-        if: github.event_name == 'push'
-        id: gcp-auth
-        uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
-          service_account: ${{ secrets.GCP_DEPLOY_SA }}
-
-      - name: Log in to Artifact Registry
-        if: github.event_name == 'push'
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.GAR_REGION }}-docker.pkg.dev
-          username: oauth2accesstoken
-          password: ${{ steps.gcp-auth.outputs.access_token }}
-
       - name: Generate tag suffix
         id: tag
         run: |
+          # Sanitize ref_name: replace / with - for valid Docker tags
           echo "suffix=$(echo '${{ github.ref_name }}' | tr '/' '-')" >> $GITHUB_OUTPUT
-          echo "sha_short=$(echo '${{ github.sha }}' | head -c 12)" >> $GITHUB_OUTPUT
 
-      - name: Build and push (amd64)
+      - name: Build and push GPU image (amd64) to GHCR
         id: build
         uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64
           push: ${{ github.event_name == 'push' }}
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.suffix }}-amd64
-            ${{ github.event_name == 'push' && format('{0}:{1}-amd64', env.GAR_REGISTRY, steps.tag.outputs.suffix) || '' }}
-            ${{ github.event_name == 'push' && format('{0}:{1}', env.GAR_REGISTRY, steps.tag.outputs.sha_short) || '' }}
+          build-args: |
+            TORCH_VARIANT=gpu
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.suffix }}-amd64
           provenance: false
           sbom: false
           cache-from: |
             type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-amd64
             type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main-amd64
           cache-to: ${{ github.event_name == 'push' && format('type=registry,ref={0}/{1}:buildcache-amd64,mode=max', env.REGISTRY, env.IMAGE_NAME) || '' }}
-
-      - name: Run Trivy vulnerability scanner
-        if: always() && steps.build.outcome == 'success'
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.suffix }}-amd64
-          format: sarif
-          output: trivy-results.sarif
-          severity: HIGH,CRITICAL
-          ignore-unfixed: true
-
-      - name: Upload Trivy scan results
-        if: always() && steps.build.outcome == 'success'
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: trivy-results.sarif
 
   build-arm64:
     if: github.event_name != 'delete'
@@ -120,13 +92,15 @@ jobs:
           # Sanitize ref_name: replace / with - for valid Docker tags
           echo "suffix=$(echo '${{ github.ref_name }}' | tr '/' '-')" >> $GITHUB_OUTPUT
 
-      - name: Build and push (arm64)
+      - name: Build and push GPU image (arm64) to GHCR
         id: build
         uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/arm64
           push: ${{ github.event_name == 'push' }}
+          build-args: |
+            TORCH_VARIANT=gpu
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.suffix }}-arm64
           provenance: false
           sbom: false
@@ -142,27 +116,12 @@ jobs:
     permissions:
       contents: read
       packages: write
-      id-token: write
     steps:
       - uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Authenticate to Google Cloud
-        id: gcp-auth
-        uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
-          service_account: ${{ secrets.GCP_DEPLOY_SA }}
-
-      - name: Log in to Artifact Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.GAR_REGION }}-docker.pkg.dev
-          username: oauth2accesstoken
-          password: ${{ steps.gcp-auth.outputs.access_token }}
 
       - name: Generate tag suffix
         id: tag
@@ -184,6 +143,7 @@ jobs:
           TAGS: ${{ steps.meta.outputs.tags }}
           SUFFIX: ${{ steps.tag.outputs.suffix }}
         run: |
+          # Iterate over multi-line tags properly
           echo "$TAGS" | while IFS= read -r tag; do
             [ -z "$tag" ] && continue
             echo "Creating manifest for: $tag"
@@ -196,23 +156,80 @@ jobs:
               "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${SUFFIX}-arm64"
           done
 
-      - name: Tag latest in Artifact Registry
-        if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
-        run: |
-          gcloud artifacts docker tags add \
-            "${{ env.GAR_REGISTRY }}:${{ steps.tag.outputs.suffix }}-amd64" \
-            "${{ env.GAR_REGISTRY }}:latest"
+  build-gar:
+    # CPU-only, amd64-only image for Cloud Run. Pushed to Artifact Registry only.
+    # Push events only (WIF secrets are unavailable on fork PRs, and the only
+    # consumer is Cloud Run, which deploys on push). PRs still validate the GPU
+    # Dockerfile build via build-amd64.
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write          # Workload Identity Federation
+      security-events: write   # Trivy SARIF upload
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
 
-      - name: Tag version in Artifact Registry
-        if: startsWith(github.ref, 'refs/tags/v')
+      - name: Authenticate to Google Cloud
+        id: gcp-auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_DEPLOY_SA }}
+
+      - name: Log in to Artifact Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.GAR_REGION }}-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.gcp-auth.outputs.access_token }}
+
+      - name: Generate tags
+        id: tag
         run: |
-          gcloud artifacts docker tags add \
-            "${{ env.GAR_REGISTRY }}:${{ steps.tag.outputs.suffix }}-amd64" \
-            "${{ env.GAR_REGISTRY }}:${{ github.ref_name }}"
+          echo "suffix=$(echo '${{ github.ref_name }}' | tr '/' '-')" >> $GITHUB_OUTPUT
+          echo "sha_short=$(echo '${{ github.sha }}' | head -c 12)" >> $GITHUB_OUTPUT
+
+      - name: Build and push CPU image (amd64) to Artifact Registry
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          build-args: |
+            TORCH_VARIANT=cpu
+          tags: |
+            ${{ env.GAR_REGISTRY }}:${{ steps.tag.outputs.sha_short }}
+            ${{ env.GAR_REGISTRY }}:${{ steps.tag.outputs.suffix }}-amd64
+            ${{ (github.ref == format('refs/heads/{0}', github.event.repository.default_branch)) && format('{0}:latest', env.GAR_REGISTRY) || '' }}
+            ${{ startsWith(github.ref, 'refs/tags/v') && format('{0}:{1}', env.GAR_REGISTRY, github.ref_name) || '' }}
+          provenance: false
+          sbom: false
+          # Cache stored in GAR (the only registry this job authenticates to).
+          cache-from: type=registry,ref=${{ env.GAR_REGISTRY }}:buildcache-gar-cpu
+          cache-to: type=registry,ref=${{ env.GAR_REGISTRY }}:buildcache-gar-cpu,mode=max
+
+      - name: Run Trivy vulnerability scanner
+        if: always() && steps.build.outcome == 'success'
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ env.GAR_REGISTRY }}:${{ steps.tag.outputs.sha_short }}
+          format: sarif
+          output: trivy-results.sarif
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+
+      - name: Upload Trivy scan results
+        if: always() && steps.build.outcome == 'success'
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-results.sarif
 
   deploy:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    needs: [create-manifest]
+    needs: [build-gar]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -225,6 +242,8 @@ jobs:
           service_account: ${{ secrets.GCP_DEPLOY_SA }}
 
       - name: Deploy to production
+        # Image only; resource config (cpu/memory/concurrency/affinity/cpu-idle)
+        # is owned by terraform/cloud_run.tf.
         uses: google-github-actions/deploy-cloudrun@v2
         with:
           service: qprimer-designer
@@ -233,7 +252,7 @@ jobs:
 
   staging-deploy:
     if: github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/')
-    needs: [build-amd64]
+    needs: [build-gar]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -244,6 +263,9 @@ jobs:
         with:
           workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
           service_account: ${{ secrets.GCP_DEPLOY_SA }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
 
       - name: Generate revision tag
         id: rev
@@ -259,23 +281,46 @@ jobs:
 
       - name: Deploy to staging
         run: |
-          gcloud run deploy qprimer-designer-staging \
+          SERVICE=qprimer-designer-staging
+          # --no-traffic is rejected on a service's first-ever revision (Cloud Run
+          # requires the first revision to take traffic). terraform creates the
+          # service shell first, so it normally exists; guard anyway for safety.
+          EXTRA_FLAGS=()
+          if gcloud run services describe "${SERVICE}" \
+              --region="${{ env.GAR_REGION }}" --project="${{ env.GAR_PROJECT }}" \
+              --format='value(name)' >/dev/null 2>&1; then
+            EXTRA_FLAGS+=("--no-traffic")
+          fi
+          # Resource sizing matches terraform/cloud_run.tf + staging.tf.
+          gcloud run deploy "${SERVICE}" \
             --image="${{ env.GAR_REGISTRY }}:${{ steps.img.outputs.sha_short }}" \
-            --region=us-central1 \
+            --region="${{ env.GAR_REGION }}" \
+            --project="${{ env.GAR_PROJECT }}" \
             --tag="${{ steps.rev.outputs.tag }}" \
-            --no-traffic \
+            --port=8080 \
             --allow-unauthenticated \
             --memory=4Gi \
             --cpu=4 \
-            --concurrency=80 \
+            --concurrency=8 \
+            --min-instances=0 \
+            --max-instances=5 \
+            --no-cpu-throttling \
+            --cpu-boost \
             --session-affinity \
-            --timeout=3600
+            --timeout=600 \
+            --quiet \
+            "${EXTRA_FLAGS[@]}"
 
       - name: Show staging URL
         run: |
+          BASE_URL=$(gcloud run services describe qprimer-designer-staging \
+            --region="${{ env.GAR_REGION }}" --project="${{ env.GAR_PROJECT }}" \
+            --format='value(status.url)')
+          HOST="${BASE_URL#https://}"
           echo "### Staging deployment" >> $GITHUB_STEP_SUMMARY
           echo "Branch: \`${{ github.ref_name }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "URL: https://${{ steps.rev.outputs.tag }}---qprimer-designer-staging-$(gcloud run services describe qprimer-designer-staging --region=us-central1 --format='value(status.url)' | sed 's|https://||' | cut -d. -f1 | sed 's|qprimer-designer-staging-||').us-central1.run.app" >> $GITHUB_STEP_SUMMARY
+          echo "Revision tag: \`${{ steps.rev.outputs.tag }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "URL: https://${{ steps.rev.outputs.tag }}---${HOST}" >> $GITHUB_STEP_SUMMARY
 
   cleanup-untagged:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,17 +68,43 @@ model_path = files('qprimer_designer.data').joinpath('combined_classifier.pth')
 
 ## Docker
 
-Pull from GitHub Container Registry:
-```bash
-docker pull ghcr.io/broadinstitute/qprimer_designer:latest
-docker run --rm ghcr.io/broadinstitute/qprimer_designer:latest qprimer --help
-```
+Two images are built from the single `Dockerfile` via the `TORCH_VARIANT` build arg:
 
-Build locally:
+- **GHCR — `ghcr.io/broadinstitute/qprimer_designer`**: multi-arch (amd64+arm64),
+  **GPU**-enabled (CUDA PyTorch). Use this for the CLI, training, and Terra/batch
+  workflows:
+  ```bash
+  docker pull ghcr.io/broadinstitute/qprimer_designer:latest
+  docker run --rm ghcr.io/broadinstitute/qprimer_designer:latest qprimer --help
+  ```
+- **GAR — `us-central1-docker.pkg.dev/sabeti-adapt/qprimer-designer/qprimer-designer`**:
+  amd64-only, **CPU**-only (slim, ~1.5–2 GB compressed). Runs the Streamlit web app on
+  Cloud Run; it has no CUDA (Cloud Run has no GPU). Not for GPU/CLI use.
+
+Build locally (GPU is the default):
 ```bash
-docker build -t qprimer-designer:local .
+docker build -t qprimer-designer:local .                          # GPU (GHCR-style)
+docker build --build-arg TORCH_VARIANT=cpu -t qprimer-cpu:local . # CPU (GAR/Cloud Run)
 docker run --rm qprimer-designer:local qprimer --help
 ```
+
+CI (`.github/workflows/docker.yml`) builds both: GPU→GHCR (multi-arch manifest) and
+CPU→GAR.
+
+## Web app deployment (Cloud Run)
+
+The Streamlit GUI (`gui/app.py`) is served publicly on Google Cloud Run in project
+`sabeti-adapt`. Infrastructure is Terraform (`terraform/`, see `terraform/README.md`):
+an Artifact Registry repo, a runtime service account, and `qprimer-designer` (prod) +
+`qprimer-designer-staging` services. CI deploys the CPU/GAR image — every branch push
+creates a per-branch staging revision (`https://<branch>---...run.app`); pushing a `v*`
+tag deploys production.
+
+Each pipeline run executes in an isolated scratch working directory
+(`gui/run_isolation.py`) so concurrent users don't share a Snakefile / `.snakemake`
+lock. Results are written to local disk, which is **ephemeral** on Cloud Run (lost on
+redeploy / scale events) in this iteration; `QPRIMER_DATA_DIR` is the seam for adding
+GCS persistence later.
 
 ## Snakemake Workflows
 
@@ -95,6 +121,10 @@ snakemake -s Snakefile.example --dry-run
 
 ## Environment Variables
 
+- `QPRIMER_DATA_DIR`: Root for GUI run outputs (`runs/`, `monitor/`). Defaults to the
+  project root (and the image's writable `/app`). Point at a mounted volume to persist
+  results, e.g. on Cloud Run (optional). Reference inputs (`target_seqs/`) always stay
+  under the project root.
 - `QPRIMER_FONT_PATH`: Custom font directory for training plots (optional)
 - `QPRIMER_TOOLPATH`: Custom tool installation path for training scripts (optional)
 - `RNASTRUCTURE_DATAPATH`: Path to RNAstructure data tables (optional)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,8 +97,13 @@ The Streamlit GUI (`gui/app.py`) is served publicly on Google Cloud Run in proje
 `sabeti-adapt`. Infrastructure is Terraform (`terraform/`, see `terraform/README.md`):
 an Artifact Registry repo, a runtime service account, and `qprimer-designer` (prod) +
 `qprimer-designer-staging` services. CI deploys the CPU/GAR image — every branch push
-creates a per-branch staging revision (`https://<branch>---...run.app`); pushing a `v*`
-tag deploys production.
+creates a per-branch staging revision; pushing a `v*` tag deploys production.
+
+URLs:
+- **Production**: `https://qprimer-designer.sabeti.broadinstitute.org`
+- **Staging base**: `https://qprimer-designer-staging-soitfyremq-uc.a.run.app`
+- **Per-branch preview**: `https://<branch>---qprimer-designer-staging-soitfyremq-uc.a.run.app`
+  (e.g. branch `my-feature` → `https://my-feature---qprimer-designer-staging-soitfyremq-uc.a.run.app`)
 
 Each pipeline run executes in an isolated scratch working directory
 (`gui/run_isolation.py`) so concurrent users don't share a Snakefile / `.snakemake`

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,12 @@ RUN qprimer --help && \
 
 WORKDIR /data
 
-CMD ["/bin/bash"]
+# Streamlit configuration for Cloud Run
+ENV STREAMLIT_SERVER_PORT=8080
+ENV STREAMLIT_SERVER_ADDRESS=0.0.0.0
+ENV STREAMLIT_SERVER_HEADLESS=true
+ENV STREAMLIT_BROWSER_GATHER_USAGE_STATS=false
+
+EXPOSE 8080
+
+CMD ["sh", "-c", "streamlit run --server.port=${PORT:-8080} --server.address=0.0.0.0 /app/gui/app.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,20 @@ LABEL org.opencontainers.image.source="https://github.com/broadinstitute/qprimer
 LABEL org.opencontainers.image.description="ML-guided qPCR primer design with off-target minimization"
 LABEL org.opencontainers.image.licenses="MIT"
 
-# Layer 1: Conda environment (cached unless environment.yml changes)
+# Layer 1: Conda environment (cached unless environment.yml or TORCH_VARIANT changes)
+#
+# TORCH_VARIANT selects the PyTorch build:
+#   gpu (default) -> CUDA-enabled build; used for the multi-arch GHCR image that
+#                    powers training and the Terra/batch CLI (which can use GPUs).
+#   cpu           -> CPU-only build (adds the `cpuonly` package); used for the slim
+#                    amd64 GAR image that runs the Streamlit web app on Cloud Run
+#                    (no GPU there). `cpuonly` is applied in the SAME solve so the
+#                    CUDA libraries are never written to a layer -- removing them in
+#                    a later layer would not shrink the image.
+ARG TORCH_VARIANT=gpu
 COPY --chown=$MAMBA_USER:$MAMBA_USER environment.yml /tmp/environment.yml
-RUN micromamba install -y -n base -f /tmp/environment.yml && \
+RUN EXTRA=""; [ "$TORCH_VARIANT" = "cpu" ] && EXTRA="cpuonly"; \
+    micromamba install -y -n base -f /tmp/environment.yml $EXTRA && \
     micromamba clean --all --yes
 
 ARG MAMBA_DOCKERFILE_ACTIVATE=1

--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ A **hosted version** runs on Google Cloud Run (project `sabeti-adapt`). It is **
 retained** across redeploys/restarts, so download anything you want to keep. See
 [`terraform/README.md`](terraform/README.md) for deployment details.
 
+| Environment | URL |
+|-------------|-----|
+| **Production** | https://qprimer-designer.sabeti.broadinstitute.org |
+| **Staging (base)** | https://qprimer-designer-staging-soitfyremq-uc.a.run.app |
+| **Per-branch preview** | `https://<branch>---qprimer-designer-staging-soitfyremq-uc.a.run.app` |
+
+Every push to a branch deploys a preview revision to the staging service (with `--no-traffic`), accessible at the per-branch URL above. Pushing a `v*` tag deploys production.
+
 The GUI uses a multi-page workflow with sidebar navigation:
 
 - **Home** — Entry point with getting started guide

--- a/README.md
+++ b/README.md
@@ -21,10 +21,15 @@ pip install .
 
 ### Using Docker
 
+The GHCR image is multi-arch (amd64+arm64) and GPU-enabled — use it for the CLI,
+training, and Terra/batch workflows:
+
 ```bash
 docker pull ghcr.io/broadinstitute/qprimer_designer:latest
 docker run --rm ghcr.io/broadinstitute/qprimer_designer qprimer --help
 ```
+
+(A separate slim, CPU-only image powers the hosted web app on Cloud Run — see below.)
 
 ## Web GUI
 
@@ -34,6 +39,11 @@ A Streamlit-based GUI is available as an alternative to the CLI. See the [GUI Ge
 pip install -e ".[gui]"
 streamlit run gui/app.py
 ```
+
+A **hosted version** runs on Google Cloud Run (project `sabeti-adapt`). It is **public
+(no login)** and **shared** — anyone with the URL can use it, and results are **not
+retained** across redeploys/restarts, so download anything you want to keep. See
+[`terraform/README.md`](terraform/README.md) for deployment details.
 
 The GUI uses a multi-page workflow with sidebar navigation:
 
@@ -226,6 +236,10 @@ The full fetched FASTA is removed after extracting the new-only subset and savin
 The pipeline also uses internal `qprimer` subcommands via Snakemake. See [docs/qprimer_cli.md](docs/qprimer_cli.md) for details.
 
 ## GPU Support
+
+Model inference auto-detects CUDA and falls back to CPU when no GPU is present. The
+GHCR image (CLI / training / Terra) is CUDA-enabled; the hosted web app runs the
+CPU-only GAR image (Cloud Run has no GPU).
 
 If GPU is available, add the resource flag:
 

--- a/docs/gui_getting_started.md
+++ b/docs/gui_getting_started.md
@@ -2,6 +2,12 @@
 
 This guide walks you through downloading the code from GitHub and launching the graphical interface on **Mac** or **Windows**.
 
+> **No-install option:** a hosted version of this GUI runs on Google Cloud Run (project
+> `sabeti-adapt`). It is **public (no login)** and **shared**, and results are **not
+> retained** between sessions/redeploys — download anything you want to keep. Ask the team
+> for the current URL (see [`../terraform/README.md`](../terraform/README.md)). Use the
+> local install below if you need persistence, privacy, or offline use.
+
 ---
 
 ## Prerequisites

--- a/gui/app.py
+++ b/gui/app.py
@@ -9,6 +9,7 @@ import signal
 import subprocess
 import sys
 import time
+import uuid
 from datetime import date, datetime
 from pathlib import Path
 
@@ -85,8 +86,17 @@ def _build_fetch_command(
 # Resolve project root (parent of gui/)
 # ---------------------------------------------------------------------------
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
-FASTA_DIR = PROJECT_ROOT / "target_seqs" / "original"
-RUNS_DIR = PROJECT_ROOT / "runs"
+
+# Persisted/output data root. Defaults to PROJECT_ROOT (local dev, and the
+# image's writable /app on Cloud Run). Set QPRIMER_DATA_DIR to a mounted volume
+# to persist results across instances/revisions (see terraform/README.md).
+# Reference inputs (target_seqs) stay under PROJECT_ROOT -- they're baked into
+# the image, not user data.
+DATA_DIR = Path(os.environ.get("QPRIMER_DATA_DIR") or PROJECT_ROOT)
+
+TARGET_SEQS_DIR = PROJECT_ROOT / "target_seqs"
+FASTA_DIR = TARGET_SEQS_DIR / "original"
+RUNS_DIR = DATA_DIR / "runs"
 SCHEMATIC_PATH = PROJECT_ROOT / "schematic.png"
 
 # Ensure the upload directory exists
@@ -97,6 +107,7 @@ sys.path.insert(0, str(PROJECT_ROOT / "src"))
 sys.path.insert(0, str(PROJECT_ROOT))
 
 from gui.snakefile_builder import build_params_txt, build_snakefile
+from gui.run_isolation import prepare_run_dir
 from qprimer_designer.utils.params import parse_params
 from qprimer_designer.adapt_cli import (
     _extract_spreadsheet_id,
@@ -117,7 +128,7 @@ from qprimer_designer.adapt_cli import (
     _uninstall_cron,
 )
 
-MONITOR_DIR = PROJECT_ROOT / "monitor"
+MONITOR_DIR = DATA_DIR / "monitor"
 MONITOR_SCHEDULE_PATH = MONITOR_DIR / "schedule.json"
 VIRUS_MAP_DATA_DIR = Path(__file__).parent / "virus_map_data"
 
@@ -1734,8 +1745,19 @@ def _preflight_checks() -> list[str]:
     return errors
 
 
+def _default_run_id() -> str:
+    """Timestamp + short random suffix so concurrent users don't collide."""
+    return datetime.now().strftime("%Y%m%d_%H%M%S") + "_" + uuid.uuid4().hex[:4]
+
+
 def _write_pipeline_files():
-    """Write Snakefile and params.txt to project root."""
+    """Build the Snakefile + params.txt for this run in an isolated scratch dir.
+
+    Returns the scratch directory to use as the Snakemake cwd. Each run gets its
+    own dir so concurrent runs never share a Snakefile / params.txt / .snakemake
+    lock; shared inputs (target_seqs) and outputs (runs/) are symlinked in.
+    See gui/run_isolation.py.
+    """
     mode = st.session_state.get("mode", "Singleplex")
     probe = st.session_state.get("probe_enabled",
                                   st.session_state.get("_probe_enabled_saved", False))
@@ -1751,7 +1773,7 @@ def _write_pipeline_files():
 
     run_id = st.session_state.get("design_run_id", "").strip()
     if not run_id:
-        run_id = datetime.now().strftime("%Y%m%d_%H%M%S")
+        run_id = _default_run_id()
     st.session_state.run_id = run_id
 
     snakefile_content = build_snakefile(
@@ -1761,11 +1783,19 @@ def _write_pipeline_files():
         panel=panel,
         run_id=run_id,
     )
-    (PROJECT_ROOT / "Snakefile").write_text(snakefile_content)
 
     _init_params()
     params_content = build_params_txt(st.session_state.params)
-    (PROJECT_ROOT / "params.txt").write_text(params_content)
+
+    scratch = prepare_run_dir(
+        run_id=run_id,
+        snakefile_content=snakefile_content,
+        params_content=params_content,
+        target_seqs_dir=TARGET_SEQS_DIR,
+        runs_dir=RUNS_DIR,
+    )
+    st.session_state.pipeline_scratch_dir = str(scratch)
+    return scratch
 
 
 # Pipeline rule steps grouped for progress display
@@ -1901,7 +1931,7 @@ def _tab_run():
     st.header("Run Design" if workflow == "design" else "Run Evaluate")
 
     # Run ID
-    default_run_id = datetime.now().strftime("%Y%m%d_%H%M%S")
+    default_run_id = _default_run_id()
     if "design_run_id" not in st.session_state:
         st.session_state["design_run_id"] = default_run_id
     st.text_input("Run ID", key="design_run_id",
@@ -1966,13 +1996,13 @@ def _tab_run():
     if st.session_state.get("pipeline_should_start"):
         st.session_state.pipeline_should_start = False
 
-        _write_pipeline_files()
+        scratch_dir = _write_pipeline_files()
 
-        # Unlock snakemake directory in case of leftover locks
+        # Unlock the (fresh) scratch dir in case of a leftover lock from a crash.
         snakemake_bin = _find_tool("snakemake") or "snakemake"
         subprocess.run(
             [snakemake_bin, "-s", "Snakefile", "--unlock", "--cores", "1"],
-            capture_output=True, cwd=str(PROJECT_ROOT),
+            capture_output=True, cwd=str(scratch_dir),
         )
 
         env = os.environ.copy()
@@ -2068,7 +2098,7 @@ def _tab_run():
             cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
-            cwd=str(PROJECT_ROOT),
+            cwd=str(scratch_dir),
             env=env,
             text=True,
         )
@@ -3118,16 +3148,20 @@ def _tab_results():
     # --- Cleanup ---
     st.subheader("Cleanup")
     if st.button("Delete all pipeline outputs", type="secondary"):
-        result = subprocess.run(
-            ["snakemake", "-s", "Snakefile", "--delete-all-output", "--cores", "1"],
-            capture_output=True,
-            text=True,
-            cwd=str(PROJECT_ROOT),
-        )
-        if result.returncode == 0:
-            st.success("Pipeline outputs deleted.")
-        else:
-            st.error(f"Cleanup failed:\n{result.stderr}")
+        # Runs now execute in isolated scratch dirs, so there's no single shared
+        # Snakefile to drive `--delete-all-output`; delete the run outputs directly.
+        try:
+            removed = 0
+            if RUNS_DIR.exists():
+                for child in RUNS_DIR.iterdir():
+                    if child.is_dir():
+                        shutil.rmtree(child, ignore_errors=True)
+                    else:
+                        child.unlink(missing_ok=True)
+                    removed += 1
+            st.success(f"Deleted {removed} pipeline output(s) from {RUNS_DIR}.")
+        except Exception as exc:
+            st.error(f"Cleanup failed: {exc}")
 
 
 # ---------------------------------------------------------------------------

--- a/gui/app.py
+++ b/gui/app.py
@@ -1774,6 +1774,11 @@ def _write_pipeline_files():
     run_id = st.session_state.get("design_run_id", "").strip()
     if not run_id:
         run_id = _default_run_id()
+    # Sanitize to safe path component: allow only word chars, hyphens, dots;
+    # prevents path traversal (e.g. "../monitor") via user-supplied run IDs.
+    run_id = re.sub(r"[^A-Za-z0-9_.-]", "_", run_id).strip(".")
+    if not run_id:
+        run_id = _default_run_id()
     st.session_state.run_id = run_id
 
     snakefile_content = build_snakefile(
@@ -2161,6 +2166,14 @@ def _tab_run():
         rc = proc.returncode
         st.session_state.pipeline_running = False
         st.session_state.pipeline_return_code = rc
+
+        # Clean up the scratch dir now that the subprocess is done — it held
+        # only the generated Snakefile/params.txt and .snakemake lock, all of
+        # which are ephemeral. Outputs landed in the shared RUNS_DIR via symlink.
+        scratch_path = st.session_state.pop("pipeline_scratch_dir", None)
+        if scratch_path:
+            import shutil as _shutil
+            _shutil.rmtree(scratch_path, ignore_errors=True)
         st.session_state.pipeline_log = log
         st.session_state.pipeline_completed_rules = completed_rules
         st.session_state.pipeline_rule_done_targets = rule_done_targets

--- a/gui/run_isolation.py
+++ b/gui/run_isolation.py
@@ -1,0 +1,66 @@
+"""Per-run working-directory isolation for the Streamlit GUI.
+
+The Streamlit app can serve several users from one process/instance (Cloud Run
+runs it with concurrency > 1). The Snakemake pipeline, however, was written to
+run from a single working directory: it reads a ``Snakefile`` + ``params.txt``
+and takes a ``.snakemake`` lock in the current directory, and most rules
+reference inputs/outputs with paths *relative* to the cwd (``target_seqs/...``,
+``runs/<RUN_ID>/...``). Two runs sharing one cwd would clobber each other's
+control files and lock.
+
+``prepare_run_dir`` gives every run its own scratch cwd containing just the
+generated ``Snakefile`` + ``params.txt`` (so the ``.snakemake`` lock is private),
+while the shared, read-mostly inputs and the persisted outputs stay where they
+are via symlinks:
+
+* ``<scratch>/target_seqs`` -> the shared ``target_seqs`` dir (baked reference
+  sequences + user uploads), so the template's relative ``target_seqs/...``
+  references resolve;
+* ``<scratch>/runs`` -> the shared ``RUNS_DIR``, so outputs land in the shared
+  (and, in future, persisted) location.
+
+This module deliberately depends only on the standard library so it can be unit
+tested without importing Streamlit / torch.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import tempfile
+from pathlib import Path
+
+
+def _slug(value: str) -> str:
+    """Filesystem-safe fragment of a run id for the scratch dir name."""
+    return re.sub(r"[^A-Za-z0-9_.-]", "_", value)[:40] or "run"
+
+
+def prepare_run_dir(
+    run_id: str,
+    snakefile_content: str,
+    params_content: str,
+    target_seqs_dir: os.PathLike | str,
+    runs_dir: os.PathLike | str,
+) -> Path:
+    """Create an isolated scratch working directory for one pipeline run.
+
+    Writes ``Snakefile`` and ``params.txt`` into a fresh temp dir and symlinks
+    the shared ``target_seqs`` inputs and ``runs`` outputs into it. Returns the
+    scratch dir, which the caller should use as the ``cwd`` for the Snakemake
+    subprocess. The shared ``runs_dir`` is created if missing.
+    """
+    target_seqs_dir = Path(target_seqs_dir).resolve()
+    runs_dir = Path(runs_dir)
+    runs_dir.mkdir(parents=True, exist_ok=True)
+
+    scratch = Path(tempfile.mkdtemp(prefix=f"qprimer_run_{_slug(run_id)}_"))
+    (scratch / "Snakefile").write_text(snakefile_content)
+    (scratch / "params.txt").write_text(params_content)
+
+    # Symlink shared inputs/outputs so the Snakefile's relative paths resolve
+    # while the .snakemake lock (created in cwd) stays private to this run.
+    os.symlink(target_seqs_dir, scratch / "target_seqs", target_is_directory=True)
+    os.symlink(runs_dir.resolve(), scratch / "runs", target_is_directory=True)
+
+    return scratch

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,10 @@
+# Local terraform state and provider plugins — do not commit.
+.terraform/
+.terraform.lock.hcl
+terraform.tfstate
+terraform.tfstate.backup
+*.tfstate
+*.tfstate.*
+
+# Local variable overrides (may contain environment-specific values).
+terraform.tfvars

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,6 +1,7 @@
 # Local terraform state and provider plugins — do not commit.
+# .terraform.lock.hcl is intentionally NOT ignored: it pins provider versions
+# for reproducible installs across machines and CI.
 .terraform/
-.terraform.lock.hcl
 terraform.tfstate
 terraform.tfstate.backup
 *.tfstate

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,42 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:79CwMTsp3Ud1nOl5hFS5mxQHyT0fGVye7pqpU0PPlHI=",
+    "zh:1f3513fcfcbf7ca53d667a168c5067a4dd91a4d4cccd19743e248ff31065503c",
+    "zh:3da7db8fc2c51a77dd958ea8baaa05c29cd7f829bd8941c26e2ea9cb3aadc1e5",
+    "zh:3e09ac3f6ca8111cbb659d38c251771829f4347ab159a12db195e211c76068bb",
+    "zh:7bb9e41c568df15ccf1a8946037355eefb4dfb4e35e3b190808bb7c4abae547d",
+    "zh:81e5d78bdec7778e6d67b5c3544777505db40a826b6eb5abe9b86d4ba396866b",
+    "zh:8d309d020fb321525883f5c4ea864df3d5942b6087f6656d6d8b3a1377f340fc",
+    "zh:93e112559655ab95a523193158f4a4ac0f2bfed7eeaa712010b85ebb551d5071",
+    "zh:d3efe589ffd625b300cef5917c4629513f77e3a7b111c9df65075f76a46a63c7",
+    "zh:d4a4d672bbef756a870d8f32b35925f8ce2ef4f6bbd5b71a3cb764f1b6c85421",
+    "zh:e13a86bca299ba8a118e80d5f84fbdd708fe600ecdceea1a13d4919c068379fe",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fec30c095647b583a246c39d557704947195a1b7d41f81e369ba377d997faef6",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google-beta" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:P2GiUJM1frlPtBViwKn1A9V2dVBdGuWcX80w9TdH8ZE=",
+    "zh:18b442bd0a05321d39dda1e9e3f1bdede4e61bc2ac62cc7a67037a3864f75101",
+    "zh:2e387c51455862828bec923a3ec81abf63a4d998da470cf00e09003bda53d668",
+    "zh:3942e708fa84ebe54996086f4b1398cb747fe19cbcd0be07ace528291fb35dee",
+    "zh:496287dd48b34ae6197cb1f887abeafd07c33f389dbe431bb01e24846754cfdd",
+    "zh:6eca885419969ce5c2a706f34dce1f10bde9774757675f2d8a92d12e5a1be390",
+    "zh:710dbef826c3fe7f76f844dae47937e8e4c1279dd9205ec4610be04cf3327244",
+    "zh:777ebf44b24bfc7bdbf770dc089f1a72f143b4718fdedb8c6bd75983115a1ec2",
+    "zh:9c8703bba37b8c7ad857efc3513392c5a096c519397c1cb822d7612f38e4262f",
+    "zh:c4f1d3a73de2702277c99d5348ad6d374705bcfdd367ad964ff4cfd2cf06c281",
+    "zh:eca8df11af3f5a948492d5b8b5d01b4ec705aad10bc30ec1524205508ae28393",
+    "zh:f41e7fd5f2628e8fd6b8ea136366923858f54428d1729898925469b862c275c2",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,77 @@
+# Terraform — qprimer-designer serving infra
+
+Provisions the public web entry point for the qprimer-designer Streamlit app on Cloud Run:
+
+```
+Internet
+   │ HTTPS (443) — Google-managed cert on the *.run.app URL
+   ▼
+Cloud Run service  (qprimer-designer, ingress=ALL, allUsers run.invoker)
+   └─ CPU-only container image from Artifact Registry
+      us-central1-docker.pkg.dev/sabeti-adapt/qprimer-designer/qprimer-designer
+```
+
+The site is **public** — no authentication. The team accepts a shared-tenant model;
+results are not sensitive and (in this iteration) are **not retained durably** — each
+Cloud Run instance keeps results on local disk only, which is lost on redeploy / scale
+events. See "Deferred" below for adding GCS persistence later.
+
+This stack creates:
+
+- The **Artifact Registry** repo the CI `build-gar` job pushes the CPU image to (with
+  cleanup policies: keep 20 recent versions; delete untagged after 7 days).
+- A **runtime service account** (`qprimer-designer-run`) the Cloud Run services run as.
+- The **production** service (`qprimer-designer`) and a **staging** service
+  (`qprimer-designer-staging`), both public, with `cpu_idle=false`, session affinity,
+  startup CPU boost, and scale-to-zero (`min_instances=0`).
+
+It does **not** create the GPU image (that lives in GHCR), any GCS bucket, or a custom
+domain mapping (see Deferred).
+
+## Image split (why GAR is CPU-only)
+
+Two images are built from one Dockerfile via the `TORCH_VARIANT` build arg:
+
+- **GHCR** — multi-arch (amd64+arm64), **GPU**-enabled. Used by training and the
+  Terra/batch CLI.
+- **GAR** — amd64-only, **CPU**-only (slim, ~1.5–2 GB vs ~4.5 GB). This is what Cloud Run
+  runs — Cloud Run has no GPU, so CUDA libraries would only bloat the image and slow cold
+  starts.
+
+## Prerequisites
+
+1. **Deploy identity (already exists, shared).** CI authenticates via Workload Identity
+   Federation as `gha-deployer@sabeti-adapt.iam.gserviceaccount.com`, which already holds
+   `roles/run.admin`, `roles/artifactregistry.writer`, and `roles/iam.serviceAccountUser`
+   at the project level — so it can deploy these services and act as the runtime SA with
+   **no extra IAM**.
+2. **GitHub repo secrets** on `broadinstitute/qprimer_designer` (same values carmen uses):
+   - `GCP_WIF_PROVIDER` — the Workload Identity provider resource name.
+   - `GCP_DEPLOY_SA` — `gha-deployer@sabeti-adapt.iam.gserviceaccount.com`.
+3. **gcloud auth** for running terraform locally: `gcloud auth application-default login`.
+
+## Apply
+
+`terraform.tfvars` can be empty — all variables have sensible defaults.
+
+```bash
+cd terraform
+terraform init
+terraform plan
+terraform apply
+```
+
+State is local and gitignored (see `.gitignore`); consider a GCS backend if more than one
+person manages this. **Bootstrap order:** apply terraform first (creates the GAR repo +
+service shells), *then* push a branch so CI can publish the CPU image and deploy revisions.
+
+## Deferred (future changes)
+
+- **GCS result persistence:** create a dedicated bucket with a 1-day lifecycle rule, mount
+  it as a gen2 GCS volume on both services, grant the runtime SA `roles/storage.objectAdmin`,
+  and set `QPRIMER_DATA_DIR` to the mount. The app already roots its data dirs at
+  `QPRIMER_DATA_DIR`, so this is config-only on the app side. Makes "Past Results" survive
+  redeploys and be shared across users.
+- **Custom domain** (`qprimer-designer.sabeti.broadinstitute.org`): add a
+  `google_cloud_run_domain_mapping`, verify the domain in `sabeti-adapt`, and add a CNAME to
+  `ghs.googlehosted.com` in the `sabeti.broadinstitute.org` Cloud DNS zone.

--- a/terraform/artifact_registry.tf
+++ b/terraform/artifact_registry.tf
@@ -1,0 +1,34 @@
+###############################################################################
+# Artifact Registry repository that holds the qprimer-designer CPU image.      #
+# The CI workflow (.github/workflows/docker.yml, job `build-gar`) pushes here. #
+# The GPU multi-arch image lives in GHCR, not here.                            #
+###############################################################################
+
+resource "google_artifact_registry_repository" "qprimer_designer" {
+  project       = var.project_id
+  location      = var.region
+  repository_id = var.gar_repository_id
+  description   = "CPU-only container image for the qprimer-designer Streamlit web app (Cloud Run)."
+  format        = "DOCKER"
+
+  cleanup_policy_dry_run = false
+
+  cleanup_policies {
+    id     = "keep-recent-versions"
+    action = "KEEP"
+    most_recent_versions {
+      keep_count = 20
+    }
+  }
+
+  cleanup_policies {
+    id     = "delete-old-untagged"
+    action = "DELETE"
+    condition {
+      tag_state  = "UNTAGGED"
+      older_than = "604800s" # 7 days
+    }
+  }
+
+  depends_on = [google_project_service.services]
+}

--- a/terraform/cloud_run.tf
+++ b/terraform/cloud_run.tf
@@ -68,3 +68,30 @@ resource "google_cloud_run_v2_service_iam_member" "public_invoker" {
   role     = "roles/run.invoker"
   member   = "allUsers"
 }
+
+###############################################################################
+# Custom domain mapping (Cloud Run v1 domain-mapping API, works with v2       #
+# services). GCP auto-provisions and renews the TLS cert once the DNS records  #
+# below are in place.                                                          #
+#                                                                              #
+# Prerequisite: the GCP identity running terraform must be a verified owner    #
+# of sabeti.broadinstitute.org in Google Search Console. One-time step per     #
+# domain, not per service.                                                      #
+###############################################################################
+
+resource "google_cloud_run_domain_mapping" "custom_domain" {
+  count    = var.custom_domain != "" ? 1 : 0
+  name     = var.custom_domain
+  location = var.region
+  project  = var.project_id
+
+  metadata {
+    namespace = var.project_id
+  }
+
+  spec {
+    route_name = google_cloud_run_v2_service.app.name
+  }
+
+  depends_on = [google_cloud_run_v2_service.app]
+}

--- a/terraform/cloud_run.tf
+++ b/terraform/cloud_run.tf
@@ -1,0 +1,70 @@
+###############################################################################
+# Cloud Run service hosting the Streamlit web app (production)                  #
+###############################################################################
+
+resource "google_cloud_run_v2_service" "app" {
+  name                = var.service_name
+  project             = var.project_id
+  location            = var.region
+  ingress             = "INGRESS_TRAFFIC_ALL"
+  deletion_protection = false
+
+  template {
+    service_account                  = google_service_account.runtime.email
+    timeout                          = "${var.cloud_run_timeout_seconds}s"
+    max_instance_request_concurrency = var.cloud_run_concurrency
+    # Streamlit's session_state lives in the Python process; pin a browser to
+    # one instance so file-upload XHRs and the websocket land together.
+    session_affinity = true
+
+    scaling {
+      min_instance_count = var.cloud_run_min_instances
+      max_instance_count = var.cloud_run_max_instances
+    }
+
+    containers {
+      image = var.image
+
+      ports {
+        container_port = 8080
+      }
+
+      resources {
+        limits = {
+          cpu    = var.cloud_run_cpu
+          memory = var.cloud_run_memory
+        }
+        # CPU always allocated (not throttled between requests): the pipeline
+        # runs snakemake as a subprocess whose work must keep progressing while
+        # the Streamlit request that launched it is in flight. (carmen can idle-
+        # throttle because it barely computes; this app cannot.)
+        cpu_idle          = false
+        startup_cpu_boost = true
+      }
+    }
+  }
+
+  # CI deploys new images via `gcloud run deploy --image ...`; terraform owns the
+  # service shell + non-image config. The image tag drifts from this default
+  # between releases — that's expected and harmless.
+  lifecycle {
+    ignore_changes = [
+      client,
+      client_version,
+      template[0].containers[0].image,
+    ]
+  }
+
+  depends_on = [google_project_service.services]
+}
+
+# Public site: ingress=ALL above lets anyone reach the service; this binding
+# lets anyone invoke. There is no auth tier — the team accepts a public,
+# shared-tenant model (results are not sensitive and are not retained durably).
+resource "google_cloud_run_v2_service_iam_member" "public_invoker" {
+  project  = google_cloud_run_v2_service.app.project
+  location = google_cloud_run_v2_service.app.location
+  name     = google_cloud_run_v2_service.app.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,29 @@
+###############################################################################
+# Required APIs                                                                #
+###############################################################################
+
+resource "google_project_service" "services" {
+  for_each = toset([
+    "run.googleapis.com",
+    "artifactregistry.googleapis.com",
+    "iamcredentials.googleapis.com",
+  ])
+  project            = var.project_id
+  service            = each.value
+  disable_on_destroy = false
+}
+
+###############################################################################
+# Service account that the Cloud Run services run as                          #
+#                                                                             #
+# Distinct from the CI deploy identity (gha-deployer@sabeti-adapt), which is  #
+# shared, pre-existing project infra and already holds run.admin +           #
+# artifactregistry.writer + iam.serviceAccountUser at the project level — so  #
+# it can deploy these services and act as this runtime SA with no extra IAM.  #
+###############################################################################
+
+resource "google_service_account" "runtime" {
+  account_id   = "${var.service_name}-run"
+  display_name = "Runtime SA for ${var.service_name} Cloud Run service"
+  project      = var.project_id
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -25,3 +25,11 @@ output "artifact_registry_repo" {
 output "runtime_service_account" {
   value = google_service_account.runtime.email
 }
+
+output "custom_domain_dns_records" {
+  description = "DNS records to add to the broadinstitute.org Cloud DNS zone. Available after terraform apply once the domain mapping is created."
+  value = var.custom_domain != "" ? try(
+    google_cloud_run_domain_mapping.custom_domain[0].status[0].resource_records,
+    []
+  ) : []
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,27 @@
+output "cloud_run_service_name" {
+  value = google_cloud_run_v2_service.app.name
+}
+
+output "cloud_run_url" {
+  description = "Direct *.run.app URL of the production service (reachable since ingress=ALL)."
+  value       = google_cloud_run_v2_service.app.uri
+}
+
+output "staging_service_name" {
+  description = "Cloud Run staging service. CI deploys per-branch tagged revisions to it."
+  value       = google_cloud_run_v2_service.staging.name
+}
+
+output "staging_base_url" {
+  description = "Base *.run.app URL of the staging service. Per-branch URLs prepend `<branch>---`."
+  value       = google_cloud_run_v2_service.staging.uri
+}
+
+output "artifact_registry_repo" {
+  description = "Artifact Registry repo the CI `build-gar` job pushes the CPU image to."
+  value       = "${var.region}-docker.pkg.dev/${var.project_id}/${var.gar_repository_id}"
+}
+
+output "runtime_service_account" {
+  value = google_service_account.runtime.email
+}

--- a/terraform/staging.tf
+++ b/terraform/staging.tf
@@ -1,0 +1,74 @@
+###############################################################################
+# Staging Cloud Run service                                                   #
+#                                                                             #
+# A second, deliberately permissive service used by CI to deploy a tagged     #
+# revision per branch push, so engineers can test changes against the real    #
+# container before merging.                                                   #
+#                                                                             #
+# Per-branch revisions are created by .github/workflows/docker.yml            #
+# (`staging-deploy`) using `gcloud run deploy --tag <branch> --no-traffic`,   #
+# which yields URLs of the form                                               #
+#   https://<branch>---<service>-<hash>.<region>.run.app                      #
+# distinct per branch, with no traffic shifting on the base URL.              #
+#                                                                             #
+# CI is the source of truth for staging revisions AND their resource config   #
+# (the gcloud flags in staging-deploy). terraform only owns the service shell #
+# + IAM, hence lifecycle.ignore_changes on the whole template.                #
+###############################################################################
+
+resource "google_cloud_run_v2_service" "staging" {
+  name                = "${var.service_name}-staging"
+  project             = var.project_id
+  location            = var.region
+  ingress             = "INGRESS_TRAFFIC_ALL"
+  deletion_protection = false
+
+  template {
+    service_account                  = google_service_account.runtime.email
+    timeout                          = "${var.cloud_run_timeout_seconds}s"
+    max_instance_request_concurrency = var.cloud_run_concurrency
+    session_affinity                 = true
+
+    scaling {
+      min_instance_count = 0
+      max_instance_count = var.cloud_run_max_instances
+    }
+
+    containers {
+      image = var.image
+
+      ports {
+        container_port = 8080
+      }
+
+      resources {
+        limits = {
+          cpu    = var.cloud_run_cpu
+          memory = var.cloud_run_memory
+        }
+        cpu_idle          = false
+        startup_cpu_boost = true
+      }
+    }
+  }
+
+  # CI is the source of truth for staging revisions; terraform only bootstraps
+  # the service shell. New revisions arrive via `gcloud run deploy --tag ...`.
+  lifecycle {
+    ignore_changes = [
+      template,
+      client,
+      client_version,
+    ]
+  }
+
+  depends_on = [google_project_service.services]
+}
+
+resource "google_cloud_run_v2_service_iam_member" "staging_public" {
+  project  = google_cloud_run_v2_service.staging.project
+  location = google_cloud_run_v2_service.staging.location
+  name     = google_cloud_run_v2_service.staging.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -13,3 +13,4 @@
 # cloud_run_memory        = "4Gi"
 # cloud_run_concurrency   = 8
 # cloud_run_timeout_seconds = 600
+# custom_domain             = "qprimer-designer.sabeti.broadinstitute.org"  # set to "" to skip

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,15 @@
+# Copy to terraform.tfvars and override only what you need.
+# terraform.tfvars is gitignored.
+#
+# All variables have suitable defaults in variables.tf for the standard
+# sabeti-adapt deployment — the file can be empty. Override as needed:
+#
+# project_id              = "sabeti-adapt"
+# region                  = "us-central1"
+# image                   = "us-central1-docker.pkg.dev/sabeti-adapt/qprimer-designer/qprimer-designer:latest"
+# cloud_run_min_instances = 0
+# cloud_run_max_instances = 5
+# cloud_run_cpu           = "4"
+# cloud_run_memory        = "4Gi"
+# cloud_run_concurrency   = 8
+# cloud_run_timeout_seconds = 600

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -63,3 +63,9 @@ variable "cloud_run_concurrency" {
   type        = number
   default     = 8
 }
+
+variable "custom_domain" {
+  description = "Custom domain to map to the production Cloud Run service. Leave empty to skip domain mapping."
+  type        = string
+  default     = "qprimer-designer.sabeti.broadinstitute.org"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,65 @@
+variable "project_id" {
+  description = "GCP project that owns the Cloud Run services and Artifact Registry repo."
+  type        = string
+  default     = "sabeti-adapt"
+}
+
+variable "region" {
+  description = "Region for the Cloud Run services and the (regional) Artifact Registry repo."
+  type        = string
+  default     = "us-central1"
+}
+
+variable "service_name" {
+  description = "Cloud Run service name and the user-visible app slug."
+  type        = string
+  default     = "qprimer-designer"
+}
+
+variable "image" {
+  description = "Fully-qualified container image to deploy. The CI workflow pushes a :<sha> tag; for steady-state deploys we point at :latest. This is the CPU-only GAR image (Cloud Run has no GPU)."
+  type        = string
+  default     = "us-central1-docker.pkg.dev/sabeti-adapt/qprimer-designer/qprimer-designer:latest"
+}
+
+variable "gar_repository_id" {
+  description = "Artifact Registry repository ID for the qprimer-designer Docker image."
+  type        = string
+  default     = "qprimer-designer"
+}
+
+variable "cloud_run_min_instances" {
+  description = "Minimum Cloud Run instances. 0 = scale to zero (accept cold starts for this low-frequency app)."
+  type        = number
+  default     = 0
+}
+
+variable "cloud_run_max_instances" {
+  description = "Maximum Cloud Run instances. Caps blast radius of misuse."
+  type        = number
+  default     = 5
+}
+
+variable "cloud_run_cpu" {
+  description = "CPU per Cloud Run instance. Heavier than carmen because the primer-design pipeline runs bowtie2 + MAFFT + torch in-process."
+  type        = string
+  default     = "4"
+}
+
+variable "cloud_run_memory" {
+  description = "Memory per Cloud Run instance. Validate against a real design run for OOM headroom."
+  type        = string
+  default     = "4Gi"
+}
+
+variable "cloud_run_timeout_seconds" {
+  description = "Per-request timeout. Typical design runs ~2 min after recent optimizations; 600s gives headroom."
+  type        = number
+  default     = 600
+}
+
+variable "cloud_run_concurrency" {
+  description = "Max concurrent requests per container. Must be >1: Streamlit's persistent websocket plus file-upload XHRs are separate Cloud Run requests, and routing the upload to a fresh sessionless instance returns 400. Kept modest so a single instance runs only a few heavy pipeline jobs; max_instances absorbs additional load. Session affinity pins a browser to one instance."
+  type        = number
+  default     = 8
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+provider "google-beta" {
+  project = var.project_id
+  region  = var.region
+}

--- a/tests/test_run_isolation.py
+++ b/tests/test_run_isolation.py
@@ -1,0 +1,83 @@
+"""Tests for gui.run_isolation.prepare_run_dir (stdlib-only; no Streamlit)."""
+
+import sys
+from pathlib import Path
+
+# gui/ lives at the repo root (not under src/), so make it importable.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from gui.run_isolation import prepare_run_dir  # noqa: E402
+
+
+def _make_target_seqs(root: Path) -> Path:
+    """Create a minimal shared target_seqs/{original,msa} tree."""
+    target_seqs = root / "target_seqs"
+    (target_seqs / "original").mkdir(parents=True)
+    (target_seqs / "msa").mkdir(parents=True)
+    (target_seqs / "original" / "virusA.fa").write_text(">virusA\nACGT\n")
+    return target_seqs
+
+
+def test_writes_control_files_and_symlinks(tmp_path):
+    target_seqs = _make_target_seqs(tmp_path)
+    runs_dir = tmp_path / "runs"
+
+    scratch = prepare_run_dir(
+        run_id="20260616_120000_abcd",
+        snakefile_content="SNAKEFILE-BODY",
+        params_content="PARAMS-BODY",
+        target_seqs_dir=target_seqs,
+        runs_dir=runs_dir,
+    )
+
+    assert scratch.is_dir()
+    assert (scratch / "Snakefile").read_text() == "SNAKEFILE-BODY"
+    assert (scratch / "params.txt").read_text() == "PARAMS-BODY"
+
+    # Symlinks make the Snakefile's relative paths resolve.
+    assert (scratch / "target_seqs").is_symlink()
+    assert (scratch / "runs").is_symlink()
+    assert (scratch / "target_seqs" / "original" / "virusA.fa").read_text().startswith(">virusA")
+    assert (scratch / "target_seqs").resolve() == target_seqs.resolve()
+    assert (scratch / "runs").resolve() == runs_dir.resolve()
+
+
+def test_runs_dir_created_when_missing(tmp_path):
+    target_seqs = _make_target_seqs(tmp_path)
+    runs_dir = tmp_path / "nested" / "runs"
+    assert not runs_dir.exists()
+
+    prepare_run_dir(
+        run_id="r1",
+        snakefile_content="s",
+        params_content="p",
+        target_seqs_dir=target_seqs,
+        runs_dir=runs_dir,
+    )
+    assert runs_dir.is_dir()
+
+
+def test_each_run_gets_a_private_dir_but_shared_output(tmp_path):
+    target_seqs = _make_target_seqs(tmp_path)
+    runs_dir = tmp_path / "runs"
+
+    s1 = prepare_run_dir("run-1", "s", "p", target_seqs, runs_dir)
+    s2 = prepare_run_dir("run-2", "s", "p", target_seqs, runs_dir)
+
+    # Distinct scratch dirs => isolated Snakefile / params.txt / .snakemake lock.
+    assert s1 != s2
+
+    # But outputs written via the per-run `runs` symlink land in the shared dir.
+    (s1 / "runs" / "run-1").mkdir()
+    (s2 / "runs" / "run-2").mkdir()
+    assert (runs_dir / "run-1").is_dir()
+    assert (runs_dir / "run-2").is_dir()
+
+
+def test_run_id_with_unsafe_chars_is_sanitized(tmp_path):
+    target_seqs = _make_target_seqs(tmp_path)
+    runs_dir = tmp_path / "runs"
+    # Slashes / spaces must not escape the temp dir or break creation.
+    scratch = prepare_run_dir("a/b c..d", "s", "p", target_seqs, runs_dir)
+    assert scratch.is_dir()
+    assert "/" not in scratch.name


### PR DESCRIPTION
## Summary

Makes the existing Streamlit GUI (`gui/app.py`) deployable as a public web app on **Google Cloud Run** (project `sabeti-adapt`), without disrupting the existing GHCR image used by the CLI / training / Terra-batch workflows. Modeled on the team's `carmen-analysis` deployment.

This branch was **rebased onto `main`**, so it includes the recent `quick_design` / GUI work (PR #68) — i.e. the runtime optimizations that make serving on Cloud Run viable.

## What's in here

### 1. Two-image Docker split (`Dockerfile`)
One `Dockerfile`, selected by a `TORCH_VARIANT` build arg:
- **GHCR** — multi-arch (amd64+arm64), **GPU** (CUDA) image. Unchanged behavior; for CLI / training / Terra-batch.
- **GAR** — amd64-only, **CPU-only** (`cpuonly`) image for Cloud Run. ~3.7 GB vs ~9.25 GB on disk (Cloud Run has no GPU), which directly shrinks cold start.

### 2. CI/CD (`.github/workflows/docker.yml`)
- GHCR GPU build + multi-arch manifest (existing path, retained).
- New **`build-gar`** job: builds the CPU image, pushes to Artifact Registry, runs Trivy on the internet-facing image.
- **`staging-deploy`** on every branch push → per-branch preview revision (`--no-traffic`); **`deploy`** on `v*` tags → production.
- Keyless auth via **Workload Identity Federation**; `concurrency` group so re-pushes cancel stale runs.

### 3. Infrastructure as code (`terraform/`)
- Artifact Registry repo (with cleanup policies), a runtime service account, and `qprimer-designer` (prod) + `qprimer-designer-staging` services with public invoker IAM.
- `min_instances=0` (scale to zero), `cpu_idle=false` (pipeline subprocess isn't throttled), session affinity, `cpu=4`/`mem=4Gi`.
- Reuses the **shared `gha-deployer` WIF identity** — no new deploy IAM.

### 4. Multi-tenancy fix (`gui/`)
- Each pipeline run executes in an isolated scratch working dir (`gui/run_isolation.py`) so concurrent users don't share a `Snakefile` / `params.txt` / `.snakemake` lock; shared inputs/outputs are symlinked in.
- `QPRIMER_DATA_DIR`-configurable output dirs (the seam for adding GCS persistence later); unique run ids.

### 5. Documentation
- `CLAUDE.md` (two-image split, `TORCH_VARIANT`, deployment, `QPRIMER_DATA_DIR`), `README.md` (hosted-app note, which image for CLI), `docs/gui_getting_started.md` (no-install hosted option), and a new `terraform/README.md`.

## Deployment status

The supporting setup has already been bootstrapped against `sabeti-adapt`:
- WIF impersonation binding for `broadinstitute/qprimer_designer` + repo secrets (`GCP_WIF_PROVIDER`, `GCP_DEPLOY_SA`) configured.
- `terraform apply` done — both services are live, custom domain mapped:

| Environment | URL |
|-------------|-----|
| **Production** | https://qprimer-designer.sabeti.broadinstitute.org |
| **Staging (base)** | https://qprimer-designer-staging-soitfyremq-uc.a.run.app |
| **Per-branch preview** | `https://<branch>---qprimer-designer-staging-soitfyremq-uc.a.run.app` |

Every push to a branch deploys a preview revision to the staging service (with `--no-traffic`), accessible at the per-branch URL. The base staging URL serves the most recently traffic-weighted revision.

- CI on this branch is green through the WIF auth + Artifact Registry login; `build-gar` → `staging-deploy` populate the staging preview.

## Scope / deferred

- Ships **ephemeral** — results live on instance-local disk and are lost on redeploy/scale events. `QPRIMER_DATA_DIR` is the seam to mount a GCS volume with a lifecycle rule later.
- **Public, no-auth, shared-tenant** (matches the `carmen-analysis` precedent).

## Verification

- CPU image: `torch.version.cuda is None`, 3.7 GB; GPU image: CUDA 12.4, 9.25 GB.
- `terraform validate` passes; per-run isolation has a unit test (`tests/test_run_isolation.py`).
- CI confirmed: WIF auth ✅ and Artifact Registry login ✅ (the original workflow was missing `token_format: access_token` — fixed here)
- Production URL confirmed live: https://qprimer-designer.sabeti.broadinstitute.org
